### PR TITLE
Patcher uses exeDir for Linux + Mac stuff

### DIFF
--- a/PathfinderPatcher/PathfinderPatcher.cs
+++ b/PathfinderPatcher/PathfinderPatcher.cs
@@ -37,9 +37,9 @@ namespace PathfinderPatcher
 
                 if(File.Exists(exeDir + "Hacknet"))
                 {
-                    var txt = File.ReadAllText("Hacknet");
+                    var txt = File.ReadAllText(exeDir + "Hacknet");
                     txt = txt.Replace("Hacknet", "HacknetPathfinder");
-                    File.WriteAllText("HacknetPathfinder", txt);
+                    File.WriteAllText(exeDir + "HacknetPathfinder", txt);
                 }
 
                 foreach (var n in new string[]{ exeDir + "Hacknet.bin.x86", exeDir + "Hacknet.bin.x86_64", exeDir + "Hacknet.bin.osx" })

--- a/PathfinderPatcher/PathfinderPatcher.cs
+++ b/PathfinderPatcher/PathfinderPatcher.cs
@@ -35,15 +35,20 @@ namespace PathfinderPatcher
                     index++;
                 }
 
-                if(File.Exists(exeDir + "Hacknet"))
+                if (File.Exists(exeDir + "Hacknet"))
                 {
                     var txt = File.ReadAllText(exeDir + "Hacknet");
                     txt = txt.Replace("Hacknet", "HacknetPathfinder");
                     File.WriteAllText(exeDir + "HacknetPathfinder", txt);
                 }
 
-                foreach (var n in new string[]{ exeDir + "Hacknet.bin.x86", exeDir + "Hacknet.bin.x86_64", exeDir + "Hacknet.bin.osx" })
-                    if(File.Exists(n)) File.Copy(n, n.Replace("Hacknet", "HacknetPathfinder"), true);
+                foreach (var n in new string[]{ exeDir + "Hacknet.bin.x86", exeDir + "Hacknet.bin.x86_64", exeDir + "Hacknet.bin.osx" }) {
+                    if (File.Exists(n)) {
+                        string file = Path.GetFileNameWithoutExtension(n);
+
+                        File.Copy(n, n.Replace(file, "HacknetPathfinder"), true);
+                    }
+                }
 
                 // Loads Hacknet.exe's assembly
                 ad = LoadAssembly(exeDir + "Hacknet.exe");

--- a/PathfinderPatcher/PathfinderPatcher.cs
+++ b/PathfinderPatcher/PathfinderPatcher.cs
@@ -35,14 +35,14 @@ namespace PathfinderPatcher
                     index++;
                 }
 
-                if(File.Exists("Hacknet"))
+                if(File.Exists(exeDir + "Hacknet"))
                 {
                     var txt = File.ReadAllText("Hacknet");
                     txt = txt.Replace("Hacknet", "HacknetPathfinder");
                     File.WriteAllText("HacknetPathfinder", txt);
                 }
 
-                foreach (var n in new string[]{ "Hacknet.bin.x86", "Hacknet.bin.x86_64", "Hacknet.bin.osx" })
+                foreach (var n in new string[]{ exeDir + "Hacknet.bin.x86", exeDir + "Hacknet.bin.x86_64", exeDir + "Hacknet.bin.osx" })
                     if(File.Exists(n)) File.Copy(n, n.Replace("Hacknet", "HacknetPathfinder"), true);
 
                 // Loads Hacknet.exe's assembly


### PR DESCRIPTION
It now uses the exeDir for copying / scanning for Linux and Mac things.