### PR TITLE
Addressed #33 fully and #34 partly

### DIFF
--- a/Pathfinder/Attribute/EventAttribute.cs
+++ b/Pathfinder/Attribute/EventAttribute.cs
@@ -1,11 +1,23 @@
 ﻿using System;
+using static Pathfinder.Event.EventManager;
+
 namespace Pathfinder.Attribute
 {
     [AttributeUsage(AttributeTargets.Method, AllowMultiple = false)]
     public class EventAttribute : AbstractPathfinderAttribute
     {
         public string DebugName;
-        public int Priority;
+        public int? Priority;
+        public bool ContinueOnCancel;
+        public bool ContinueOnThrow;
+
+        internal ListenerOptions Options =>
+            new ListenerOptions {
+                DebugName = DebugName,
+                PriorityStore = Priority,
+                ContinueOnCancel = ContinueOnCancel,
+                ContinueOnThrow = ContinueOnCancel
+            };
 
         public EventAttribute(string debugName = null, int priority = 0, Type mod = null) : base(mod)
         {

--- a/Pathfinder/Attribute/EventAttribute.cs
+++ b/Pathfinder/Attribute/EventAttribute.cs
@@ -7,14 +7,15 @@ namespace Pathfinder.Attribute
     public class EventAttribute : AbstractPathfinderAttribute
     {
         public string DebugName;
-        public int? Priority;
+        public int Priority { set => PriorityStore = value; get => PriorityStore.Value; }
+        public int? PriorityStore { get; set; } = null;
         public bool ContinueOnCancel;
         public bool ContinueOnThrow;
 
         internal ListenerOptions Options =>
             new ListenerOptions {
                 DebugName = DebugName,
-                PriorityStore = Priority,
+                PriorityStore = PriorityStore,
                 ContinueOnCancel = ContinueOnCancel,
                 ContinueOnThrow = ContinueOnCancel
             };

--- a/Pathfinder/Event/PathfinderEvent.cs
+++ b/Pathfinder/Event/PathfinderEvent.cs
@@ -1,9 +1,12 @@
-﻿namespace Pathfinder.Event
+﻿using System;
+using System.Collections.Generic;
+
+namespace Pathfinder.Event
 {
     public abstract class PathfinderEvent
     {
         public bool IsCancelled { get; set; }
         public bool PreventCall { get; set; }
-        public virtual void CallEvent() { EventManager.CallEvent(this); }
+        public virtual Dictionary<string, Exception> CallEvent() { return EventManager.CallEvent(this); }
     }
 }

--- a/Pathfinder/Extension/ExtensionHandler.cs
+++ b/Pathfinder/Extension/ExtensionHandler.cs
@@ -151,13 +151,13 @@ namespace Pathfinder.Extension
                     Port.Handler.UnregisterPort(p.Key);
                 }
 
-            var events = new List<ListenerTuple>();
+            var events = new List<ListenerObject>();
             foreach (var v in EventManager.eventListeners.Values)
                 events.AddRange(v.FindAll(t => t.Item3 == id));
             foreach (var list in EventManager.eventListeners.ToArray())
             {
                 if(!tuple.Item1.eventListeners.ContainsKey(list.Key))
-                    tuple.Item1.eventListeners.Add(list.Key, new List<ListenerTuple>());
+                    tuple.Item1.eventListeners.Add(list.Key, new List<ListenerObject>());
                 foreach (var e in events)
                 {
                     if(!tuple.Item1.eventListeners[list.Key].Contains(e))

--- a/Pathfinder/Extension/ExtensionHandler.cs
+++ b/Pathfinder/Extension/ExtensionHandler.cs
@@ -80,10 +80,10 @@ namespace Pathfinder.Extension
             foreach (var p in tuple.Item1.ports)
                 Port.Handler.RegisterPort(p.Key, p.Value);
             foreach (var e in tuple.Item1.eventListeners)
-                if (EventManager.eventListeners.ContainsKey(e.Key))
-                    EventManager.eventListeners[e.Key].AddRange(e.Value);
+                if (eventListeners.ContainsKey(e.Key))
+                    eventListeners[e.Key].AddRange(e.Value);
                 else
-                    EventManager.eventListeners.Add(e.Key, e.Value);
+                    eventListeners.Add(e.Key, e.Value);
             CanRegister = false;
             ActiveInfo = info;
         }
@@ -152,9 +152,9 @@ namespace Pathfinder.Extension
                 }
 
             var events = new List<ListenerObject>();
-            foreach (var v in EventManager.eventListeners.Values)
-                events.AddRange(v.FindAll(t => t.Item3 == id));
-            foreach (var list in EventManager.eventListeners.ToArray())
+            foreach (var v in eventListeners.Values)
+                events.AddRange(v.FindAll(t => t.ModId == id));
+            foreach (var list in eventListeners.ToArray())
             {
                 if(!tuple.Item1.eventListeners.ContainsKey(list.Key))
                     tuple.Item1.eventListeners.Add(list.Key, new List<ListenerObject>());

--- a/Pathfinder/Extension/ExtensionInfo.cs
+++ b/Pathfinder/Extension/ExtensionInfo.cs
@@ -15,8 +15,8 @@ namespace Pathfinder.Extension
         internal Dictionary<string, Mission.Interface> missions = new Dictionary<string, Mission.Interface>();
         internal Dictionary<string, Mission.IGoal> goals = new Dictionary<string, Mission.IGoal>();
         internal Dictionary<string, Port.Type> ports = new Dictionary<string, Port.Type>();
-        internal Dictionary<Type, List<ListenerTuple>> eventListeners =
-            new Dictionary<Type, List<ListenerTuple>>();
+        internal Dictionary<Type, List<ListenerObject>> eventListeners =
+            new Dictionary<Type, List<ListenerObject>>();
 
         /// <summary>
         /// Gets the extension identifier.

--- a/Pathfinder/Internal/HandlerListener.cs
+++ b/Pathfinder/Internal/HandlerListener.cs
@@ -62,12 +62,11 @@ namespace Pathfinder.Internal
 
         public static void DaemonLoadListener(Computer c, SaxProcessor.ElementInfo info)
         {
-            Daemon.Interface i;
             var customDaemonInfos = info.Elements.Where(cdi => cdi.Name.ToLower() == "moddeddamon");
             foreach (var daemonInfo in customDaemonInfos)
             {
                 var id = daemonInfo.Attributes.GetValue("interfaceId");
-                if (id != null && Daemon.Handler.ModDaemons.TryGetValue(id, out i))
+                if (id != null && Daemon.Handler.ModDaemons.TryGetValue(id, out Daemon.Interface i))
                 {
                     var objs = new Dictionary<string, string>();
                     var storedObjects = daemonInfo.Attributes.GetValue("storedObjects")?.Split(' ');
@@ -81,10 +80,11 @@ namespace Pathfinder.Internal
 
         public static void ExecutableListener(ExecutableExecuteEvent e)
         {
-            Tuple<Executable.Interface, string> tuple;
             Console.WriteLine(Utility.ConvertFromHexBlocks(e.ExecutableFile.data.Split('\n')[0]));
             if (Executable.Handler.IsFileDataForModExe(e.ExecutableFile.data)
-                && Executable.Handler.ModExecutables.TryGetValue(Utility.ConvertFromHexBlocks(e.ExecutableFile.data.Split('\n')[0]), out tuple))
+                && Executable.Handler.ModExecutables.TryGetValue(
+                    Utility.ConvertFromHexBlocks(e.ExecutableFile.data.Split('\n')[0]),
+                    out Tuple<Executable.Interface, string> tuple))
             {
                 int num = e.OS.ram.bounds.Y + RamModule.contentStartOffset;
                 foreach (var exe in e.OS.exes)

--- a/Pathfinder/ModManager/Manager.cs
+++ b/Pathfinder/ModManager/Manager.cs
@@ -30,7 +30,7 @@ namespace Pathfinder.ModManager
             (
                 from pair in LoadedMods
                 where !(pair.Value is Placeholder)
-                select pair 
+                select pair
             ).ToDictionary(pair => pair.Key, pair => pair.Value);
 
         public static IEnumerable<Type> GetModTypes(this Assembly asm) =>
@@ -74,7 +74,7 @@ namespace Pathfinder.ModManager
             foreach (var mod in OperationalMods)
             {
                 if (mod.Value is Placeholder) continue;
-                using(var _ = new CurrentModOverride(mod.Value))
+                using (var _ = new CurrentModOverride(mod.Value))
                 {
                     Logger.Verbose("Loading mod '{0}'s content", mod.Key);
 
@@ -94,7 +94,7 @@ namespace Pathfinder.ModManager
         {
             foreach (var mod in OperationalMods)
             {
-                using(var _ = new CurrentModOverride(mod.Value))
+                using (var _ = new CurrentModOverride(mod.Value))
                 {
                     Logger.Verbose("Unloading mod '{0}'", mod.Key);
                     mod.Value.Unload();
@@ -117,8 +117,8 @@ namespace Pathfinder.ModManager
             foreach (var mod in MarkedModsForLoad)
             {
                 newMod = LoadMod(mod.GetType());
-                using(var _ = new CurrentModOverride(newMod));
-                    newMod.LoadContent();
+                using (var _ = new CurrentModOverride(newMod)) ;
+                newMod.LoadContent();
             }
             MarkedModsForLoad.Clear();
         }
@@ -127,7 +127,7 @@ namespace Pathfinder.ModManager
         {
             if (mod == null || mod is Placeholder) return;
 
-            using(var _ = new CurrentModOverride(mod))
+            using (var _ = new CurrentModOverride(mod))
             {
                 var name = Utility.ActiveModId;
 
@@ -143,27 +143,27 @@ namespace Pathfinder.ModManager
 
                 foreach (var e in
                          (from p in Extension.Handler.ModExtensions
-                            where p.Key.IndexOf('.') != -1 && p.Key.Remove(p.Key.IndexOf('.')) == name
-                            select p.Key)
+                          where p.Key.IndexOf('.') != -1 && p.Key.Remove(p.Key.IndexOf('.')) == name
+                          select p.Key)
                          .ToArray()
                         )
-                        Extension.Handler.UnregisterExtension(e);
+                    Extension.Handler.UnregisterExtension(e);
 
                 foreach (var e in
                          (from p in Executable.Handler.ModExecutables
-                            where p.Key.IndexOf('.') != -1 && p.Key.Remove(p.Key.IndexOf('.')) == name
-                            select p.Key)
+                          where p.Key.IndexOf('.') != -1 && p.Key.Remove(p.Key.IndexOf('.')) == name
+                          select p.Key)
                          .ToArray()
                         )
-                        Executable.Handler.UnregisterExecutable(e);
+                    Executable.Handler.UnregisterExecutable(e);
 
                 foreach (var d in
                          (from p in Daemon.Handler.ModDaemons
-                            where p.Key.IndexOf('.') != -1 && p.Key.Remove(p.Key.IndexOf('.')) == name
-                            select p.Key)
+                          where p.Key.IndexOf('.') != -1 && p.Key.Remove(p.Key.IndexOf('.')) == name
+                          select p.Key)
                          .ToArray()
                         )
-                        Daemon.Handler.UnregisterDaemon(d);
+                    Daemon.Handler.UnregisterDaemon(d);
 
                 Command.Handler.ModIdToCommandKeyList.TryGetValue(name, out List<string> clist);
                 if (clist != null)
@@ -194,10 +194,10 @@ namespace Pathfinder.ModManager
                         )
                     Port.Handler.UnregisterPort(p);
 
-                var events = new List<ListenerTuple>();
-                foreach (var v in EventManager.eventListeners.Values)
-                    events.AddRange(v.FindAll(t => t.Item3 == name));
-                foreach (var list in EventManager.eventListeners.ToArray())
+                var events = new List<ListenerObject>();
+                foreach (var v in eventListeners.Values)
+                    events.AddRange(v.FindAll(t => t.ModId == name));
+                foreach (var list in eventListeners.ToArray())
                     foreach (var e in events)
                         list.Value.Remove(e);
 
@@ -247,14 +247,14 @@ namespace Pathfinder.ModManager
                 if (!Pathfinder.IsModIdentifierValid(name, true))
                     return null; // never reached due to throw
                 Logger.Info("Loading mod '{0}'", name);
-                using(var _ = new CurrentModOverride(mod))
+                using (var _ = new CurrentModOverride(mod))
                 {
                     if (ModAttributeHandler.ModToEventMethods.TryGetValue(CurrentMod.GetType(), out List<MethodInfo> infos))
                         foreach (var i in infos)
                         {
                             var eventAttrib = i.GetFirstAttribute<EventAttribute>();
                             var paramType = i.GetParameters()[0].ParameterType;
-                            RegisterListener(paramType, i.CreateDelegate<Action<PathfinderEvent>>(typeof(Action<>).MakeGenericType(paramType)), eventAttrib.DebugName, eventAttrib.Priority);
+                            RegisterListener(paramType, i.CreateDelegate<Action<PathfinderEvent>>(typeof(Action<>).MakeGenericType(paramType)), eventAttrib.Options);
                         }
                     mod.Load();
                     UnloadedModIds.Remove(name);

--- a/Pathfinder/PathfinderHooks.cs
+++ b/Pathfinder/PathfinderHooks.cs
@@ -18,6 +18,7 @@ using Pathfinder.Util;
 using static Pathfinder.Attribute.PatchAttribute;
 using Pathfinder.Util.Types;
 using static Pathfinder.Event.DrawMainMenuTitlesEvent;
+using Pathfinder.Game.OS;
 
 namespace Pathfinder
 {
@@ -80,7 +81,10 @@ namespace Pathfinder
             {
                 Disconnects = true
             };
-            commandSentEvent.CallEvent();
+            var exceptions = commandSentEvent.CallEvent();
+            if(exceptions.Count > 0)
+                foreach (var pair in exceptions)
+                    os.Write("Command Listener Method '{0}' failed with: {1}", pair.Key, pair.Value);
             disconnects = commandSentEvent.Disconnects;
             returnFlag = disconnects;
             if (commandSentEvent.IsCancelled)
@@ -109,7 +113,10 @@ namespace Pathfinder
         {
             var commandFinishedEvent = new Event.CommandFinishedEvent(commandSentEvent);
             commandSentEvent.PreventCall = true;
-            commandFinishedEvent.CallEvent();
+            var exceptions = commandFinishedEvent.CallEvent();
+            if (exceptions.Count > 0)
+                foreach (var pair in exceptions)
+                    commandSentEvent.OS.Write("Command End Listener Method '{0}' failed with: {1}", pair.Key, pair.Value);
             disconnects = commandSentEvent.Disconnects;
             returnFlag = disconnects;
         }
@@ -349,7 +356,10 @@ namespace Pathfinder
 
             var executableExecuteEvent =
                 new Event.ExecutableExecuteEvent(com, fol, finde, f, os, args);
-            executableExecuteEvent.CallEvent();
+            var exceptions = executableExecuteEvent.CallEvent();
+            if (exceptions.Count > 0)
+                foreach (var pair in exceptions)
+                    os.Write("Executable Listener Method '{0}' failed with: {1}", pair.Key, pair.Value);
             result = (int)executableExecuteEvent.Result;
             if (executableExecuteEvent.IsCancelled || result != -1)
                 return true;
@@ -371,7 +381,10 @@ namespace Pathfinder
         {
             var portExecutableExecuteEvent =
                 new Event.ExecutablePortExecuteEvent(self, dest, name, data, port, args);
-            portExecutableExecuteEvent.CallEvent();
+            var exceptions = portExecutableExecuteEvent.CallEvent();
+            if (exceptions.Count > 0)
+                foreach (var pair in exceptions)
+                    self.Write("PortHack Listener Method '{0}' failed with: {1}", pair.Key, pair.Value);
             name = portExecutableExecuteEvent.ExecutableName;
             data = portExecutableExecuteEvent.ExecutableData;
             if (portExecutableExecuteEvent.IsCancelled)


### PR DESCRIPTION
Simplified Event Listener handling with ListenerOptions and ListenerObject
Misc Cleanup in HandlerListener
Added Terminal Exception reports for PortHacks, Commands, and Executables
Renamed ListenerTuple to ListenerObject
Added capability for Event Listeners to continue operating on Exception throws and event canceling
Updated Eventattribute and related methods for new canel and throw management