### PR TITLE
Fix adding abstract property `Properties` to the wrong type

### DIFF
--- a/PathfinderPatcher/PathfinderPatcher.cs
+++ b/PathfinderPatcher/PathfinderPatcher.cs
@@ -185,6 +185,8 @@ namespace PathfinderPatcher
                 }.Build(gameAssembly.MainModule);
                 gameAssembly.MainModule.Types.Add(nestedType);
 
+                type = gameAssembly.MainModule.GetType("Hacknet.FileType");
+
 
                 // Create FileProperties Properties getter/setter Property in FileType
                 type.AddUndefinedProperty("Properties", nestedType);


### PR DESCRIPTION
> Basically: [that line](https://github.com/Arkhist/Hacknet-Pathfinder/blob/f4236690ea5b26e42f5ebb2988226c1fe9bac999/PathfinderPatcher/PathfinderPatcher.cs#L190) is supposed to modify the interface `Hacknet.FileType` from
> ```csharp
> namespace Hacknet
> {
>  public interface FileType
>  {
>     string getName();
>  }
> }
> ```
>
> to
> ```csharp
> namespace Hacknet
> {
>   public interface FileType
>   {
>     string getName();
>     FileProperties Properties { get; set; }
>   }
> }
> ```
> (or something similar, I don't 100% know off the top of my head how properties work in interfaces)

> However, on `master`, it *instead* stricts that as an `abstract` on `ComputerLoader`.

> On `patcher-cfg`, because I moved the other modifications we do on `ComputerLoader` to my task system, it instead sticks that on *`Computer`*.

> Which is instanciated. And that causes problems.
> Because we have a `abstract` property in a non-`abstract` class.

This PR fixes the issue by assigning the correct type to the `type` local before messing about with it.