### PR TITLE
Removes reference issues i noticed

### DIFF
--- a/BepInEx.Hacknet/BepInEx.Hacknet.csproj
+++ b/BepInEx.Hacknet/BepInEx.Hacknet.csproj
@@ -63,7 +63,7 @@
     <Reference Include="Mono.Cecil.Rocks, Version=0.11.3.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e">
       <HintPath>..\libs\Mono.Cecil.Rocks.dll</HintPath>
     </Reference>
-    <Reference Include="MonoMod.RuntimeDetour, Version=21.1.11.1, Culture=neutral, PublicKeyToken=null">
+    <Reference Include="MonoMod.RuntimeDetour, Version=21.4.21.3, Culture=neutral, PublicKeyToken=null">
       <HintPath>..\libs\MonoMod.RuntimeDetour.dll</HintPath>
     </Reference>
     <Reference Include="MonoMod.Utils, Version=21.1.11.1, Culture=neutral, processorArchitecture=MSIL">

--- a/BepInEx.Hacknet/BepInEx.Hacknet.csproj
+++ b/BepInEx.Hacknet/BepInEx.Hacknet.csproj
@@ -54,11 +54,6 @@
     <Reference Include="Mono.Cecil, Version=0.11.3.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e">
       <HintPath>..\libs\Mono.Cecil.dll</HintPath>
     </Reference>
-    <Reference Include="Mono.Cecil, Version=0.11.3.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\libs\Mono.Cecil.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
     <Reference Include="Mono.Cecil.Mdb, Version=0.11.3.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e">
       <HintPath>..\libs\Mono.Cecil.Mdb.dll</HintPath>
     </Reference>

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Install the mod by placing it in Hacknet/BepInEx/plugins or a folder called Plug
 2. Compile PathfinderPatcher and run it in the Hacknet directory
 3. Copy HacknetPathfinder.dll and FNA.dll to the libs/ directory
 4. Everything else should now compile fine
-5. Everything in BepInEx.Hacknet/bin/Debug goes into Hacknet/BepInEx/core, also grab Mono.Cecil.dll from the libs folder, for some reason it won't copy to the output directory.
+5. Everything in BepInEx.Hacknet/bin/Debug goes into Hacknet/BepInEx/core.
 6. Copy/symlink the .dll (or their containing folder) for PathfinderAPI and optionally ExampleMod to Hacknet/BepInEx/plugins
 
 ## Links


### PR DESCRIPTION
Removed duplicate Mono.Cecil reference in BepInEx
Bumped the RuntimeDetour version to the version used in the release