### PR TITLE
Fix issue #67: Node lookup performance

### DIFF
--- a/PathfinderAPI/BaseGameFixes/Performance/NodeLookup.cs
+++ b/PathfinderAPI/BaseGameFixes/Performance/NodeLookup.cs
@@ -36,5 +36,12 @@ namespace Pathfinder.BaseGameFixes.Performance
             __result = ComputerLookup.Find(ip_Or_ID_or_Name);
             return false;
         }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(OS), nameof(OS.quitGame))]
+        internal static void ClearOnQuitGame()
+        {
+            ComputerLookup.ClearLookups();
+        }
     }
 }

--- a/PathfinderAPI/BaseGameFixes/Performance/NodeLookup.cs
+++ b/PathfinderAPI/BaseGameFixes/Performance/NodeLookup.cs
@@ -1,0 +1,40 @@
+﻿using Hacknet;
+using HarmonyLib;
+using Pathfinder.Util;
+
+namespace Pathfinder.BaseGameFixes.Performance
+{
+    [HarmonyPatch]
+    internal static class NodeLookup
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(ComputerLoader), nameof(ComputerLoader.loadComputer))]
+        internal static void PopulateOnComputerCreation(ref object __result)
+        {
+            ComputerLookup.PopulateLookups((Computer) __result);
+        }
+
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(Computer), nameof(Computer.load))]
+        internal static void PopulateOnComputerLoad(ref Computer __result)
+        {
+            ComputerLookup.PopulateLookups(__result);
+        }
+        
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(ComputerLoader), nameof(ComputerLoader.findComp))]
+        internal static bool ModifyComputerLoaderLookup(ref Computer __result, ref string target)
+        {
+            __result = ComputerLookup.FindById(target);
+            return false;
+        }
+
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(Programs), nameof(Programs.getComputer))]
+        internal static bool ModifyProgramsLookup(ref Computer __result, ref string ip_Or_ID_or_Name)
+        {
+            __result = ComputerLookup.Find(ip_Or_ID_or_Name);
+            return false;
+        }
+    }
+}

--- a/PathfinderAPI/PathfinderAPI.csproj
+++ b/PathfinderAPI/PathfinderAPI.csproj
@@ -76,6 +76,7 @@
     <Compile Include="BaseGameFixes\HHBS.cs" />
     <Compile Include="BaseGameFixes\MissionListingServerLoadTime.cs" />
     <Compile Include="BaseGameFixes\NeedsMissionComplete.cs" />
+    <Compile Include="BaseGameFixes\Performance\NodeLookup.cs" />
     <Compile Include="BaseGameFixes\SendEmailMission.cs" />
     <Compile Include="BaseGameFixes\StartingActionsAfterNodes.cs" />
     <Compile Include="Command\CommandManager.cs" />
@@ -109,6 +110,7 @@
     <Compile Include="Replacements\SaveWriter.cs" />
     <Compile Include="Util\AssemblyAssociatedList.cs" />
     <Compile Include="Util\DictionaryExtensions.cs" />
+    <Compile Include="Util\ComputerLookup.cs" />
     <Compile Include="Util\StringExtensions.cs" />
     <Compile Include="Util\InitializeAttribute.cs" />
     <Compile Include="PathfinderAPIPlugin.cs" />

--- a/PathfinderAPI/Util/ComputerLookup.cs
+++ b/PathfinderAPI/Util/ComputerLookup.cs
@@ -1,0 +1,52 @@
+﻿using System;
+using System.Collections.Generic;
+using Hacknet;
+
+namespace Pathfinder.Util
+{
+    [Flags]
+    public enum SearchType
+    {
+        Id   = 0b001,
+        Ip   = 0b010,
+        Name = 0b100,
+        Any  = 0b111
+    }
+    
+    public static class ComputerLookup
+    {
+        #region Lookup Tables
+        private static readonly Dictionary<string, Computer> idLookup = new Dictionary<string, Computer>();
+
+        private static readonly Dictionary<string, Computer> ipLookup = new Dictionary<string, Computer>();
+
+        private static readonly Dictionary<string, Computer> nameLookup = new Dictionary<string, Computer>();
+        #endregion
+        
+        internal static void PopulateLookups(Computer node)
+        {
+            idLookup[node.idName] = node;
+            ipLookup[node.ip]     = node;
+            nameLookup[node.name] = node;
+        }
+
+        public static Computer Find(string target, SearchType type = SearchType.Any)
+        {
+            Computer node = null;
+            if (target == null) return null;
+            if ((type & SearchType.Id) != 0)
+                node = FindById(target);
+            if (node == null && (type & SearchType.Ip) != 0)
+                node = FindByIp(target);
+            if (node == null && (type & SearchType.Name) != 0)
+                node = FindByName(target);
+            return node;
+        }
+
+        public static Computer FindById(string id) => idLookup.GetOrDefault(id);
+
+        public static Computer FindByIp(string ip) => ipLookup.GetOrDefault(ip.Filter());
+
+        public static Computer FindByName(string name) => nameLookup.GetOrDefault(name.Filter());
+    }
+}

--- a/PathfinderAPI/Util/ComputerLookup.cs
+++ b/PathfinderAPI/Util/ComputerLookup.cs
@@ -30,6 +30,13 @@ namespace Pathfinder.Util
             nameLookup[node.name] = node;
         }
 
+        internal static void ClearLookups()
+        {
+            idLookup.Clear();
+            ipLookup.Clear();
+            nameLookup.Clear();
+        }
+
         public static Computer Find(string target, SearchType type = SearchType.Any)
         {
             Computer node = null;

--- a/PathfinderAPI/Util/DictionaryExtensions.cs
+++ b/PathfinderAPI/Util/DictionaryExtensions.cs
@@ -38,7 +38,10 @@ namespace Pathfinder.Util
             
             throw new KeyNotFoundException(exMessage);
         }
-        
+
+        public static TValue GetOrDefault<TKey, TValue>(this Dictionary<TKey, TValue> dict, TKey key) =>
+            dict.TryGetValue(key, out var value) ? value : default;
+
         public static int GetInt<Key>(this Dictionary<Key, string> dict, Key key, int defaultVal = 0)
         {
             if (dict.TryGetValue(key, out var val) && int.TryParse(val, out var ret))


### PR DESCRIPTION
This PR patches the `ComputerLoader` and `Programs` classes to use a Dictionary-based lookup instead of iterating a List. (Patch class can be found at `Pathfinder.BaseGameFixes.Performance.NodeLookup`)

It also provides a small utility API for fetching a `Computer` from the computer's IP, ID, or name via `Pathfinder.Util.ComputerLookup`.