### PR TITLE
New IXmlName Interface

### DIFF
--- a/PathfinderAPI/Action/ActionManager.cs
+++ b/PathfinderAPI/Action/ActionManager.cs
@@ -59,14 +59,10 @@ namespace Pathfinder.Action
         public static void UnregisterAction<T>() where T : PathfinderAction => UnregisterAction(typeof(T));
         public static void UnregisterAction(Type actionType)
         {
-            var xmlName = CustomActions.FirstOrDefault(x => x.Value == actionType).Key;
-            if (xmlName != null)
+            foreach(var xmlName in CustomActions.Where(x => x.Value == actionType).Select(x => x.Key).ToList())
                 CustomActions.Remove(xmlName);
-            if (XmlNames.ContainsKey(actionType))
-            {
-                /* TODO: Get next name? */
+            if(XmlNames.ContainsKey(actionType))
                 XmlNames.Remove(actionType);
-            }
         }
         public static void UnregisterAction(string xmlName)
         {
@@ -74,11 +70,14 @@ namespace Pathfinder.Action
                 return;
             var actionType = CustomActions[xmlName];
             CustomActions.Remove(xmlName);
-            if (XmlNames[actionType] == xmlName)
-            {
-                /* TODO: Get next name? */
+            if (XmlNames[actionType] != xmlName)
+                return;
+            /* find the next applicable name */
+            string nextName = CustomActions.FirstOrDefault(x => x.Value == actionType).Key;
+            if (nextName == null)
                 XmlNames.Remove(actionType);
-            }
+            else
+                XmlNames[actionType] = nextName;
         }
         public static string GetXmlNameFor(Type type)
         {

--- a/PathfinderAPI/Action/ActionManager.cs
+++ b/PathfinderAPI/Action/ActionManager.cs
@@ -16,6 +16,7 @@ namespace Pathfinder.Action
     public static class ActionManager
     {
         private static readonly Dictionary<string, Type> CustomActions = new Dictionary<string, Type>();
+        private static readonly Dictionary<Type, string> XmlNames = new Dictionary<Type, string>();
 
         static ActionManager()
         {
@@ -38,8 +39,11 @@ namespace Pathfinder.Action
         private static void OnPluginUnload(Assembly pluginAsm)
         {
             var allTypes = pluginAsm.GetTypes();
-            foreach (var name in CustomActions.Where(x => allTypes.Contains(x.Value)).Select(x => x.Key).ToList())
-                CustomActions.Remove(name);
+            foreach (var entry in CustomActions.Where(x => allTypes.Contains(x.Value)).ToList())
+            {
+                CustomActions.Remove(entry.Key);
+                XmlNames.Remove(entry.Value);
+            }
         }
         
         public static void RegisterAction<T>(string xmlName) where T : PathfinderAction => RegisterAction(typeof(T), xmlName);
@@ -48,6 +52,8 @@ namespace Pathfinder.Action
             if (!typeof(PathfinderAction).IsAssignableFrom(actionType))
                 throw new ArgumentException("Action type must inherit from Pathfinder.Action.PathfinderAction!", nameof(actionType));
             CustomActions.Add(xmlName, actionType);
+            if (!XmlNames.ContainsKey(actionType))
+                XmlNames.Add(actionType, xmlName);
         }
 
         public static void UnregisterAction<T>() where T : PathfinderAction => UnregisterAction(typeof(T));
@@ -56,10 +62,28 @@ namespace Pathfinder.Action
             var xmlName = CustomActions.FirstOrDefault(x => x.Value == actionType).Key;
             if (xmlName != null)
                 CustomActions.Remove(xmlName);
+            if (XmlNames.ContainsKey(actionType))
+            {
+                /* TODO: Get next name? */
+                XmlNames.Remove(actionType);
+            }
         }
         public static void UnregisterAction(string xmlName)
         {
+            if (!CustomActions.ContainsKey(xmlName))
+                return;
+            var actionType = CustomActions[xmlName];
             CustomActions.Remove(xmlName);
+            if (XmlNames[actionType] == xmlName)
+            {
+                /* TODO: Get next name? */
+                XmlNames.Remove(actionType);
+            }
+        }
+        public static string GetXmlNameFor(Type type)
+        {
+            XmlNames.TryGetValue(type, out string retVal);
+            return retVal;
         }
         
         [HarmonyPrefix]

--- a/PathfinderAPI/Action/ConditionManager.cs
+++ b/PathfinderAPI/Action/ConditionManager.cs
@@ -58,15 +58,10 @@ namespace Pathfinder.Action
         public static void UnregisterCondition<T>() where T : PathfinderCondition => UnregisterCondition(typeof(T));
         public static void UnregisterCondition(Type conditionType)
         {
-            var xmlName = CustomConditions.FirstOrDefault(x => x.Value == conditionType).Key;
-            if (xmlName != null)
+            foreach(var xmlName in CustomConditions.Where(x => x.Value == conditionType).Select(x => x.Key).ToList())
                 CustomConditions.Remove(xmlName);
-
-            if (XmlNames.ContainsKey(conditionType))
-            {
-                /* TODO: Get next name? */
+            if(XmlNames.ContainsKey(conditionType))
                 XmlNames.Remove(conditionType);
-            }
         }
         public static void UnregisterCondition(string xmlName)
         {
@@ -74,11 +69,14 @@ namespace Pathfinder.Action
                 return;
             var conditionType = CustomConditions[xmlName];
             CustomConditions.Remove(xmlName);
-            if (XmlNames[conditionType] == xmlName)
-            {
-                /* TODO: Get next name? */
+            if (XmlNames[conditionType] != xmlName)
+                return;
+            /* find the next applicable name */
+            string nextName = CustomConditions.FirstOrDefault(x => x.Value == conditionType).Key;
+            if (nextName == null)
                 XmlNames.Remove(conditionType);
-            }
+            else
+                XmlNames[conditionType] = nextName;
         }
         public static string GetXmlNameFor(Type type)
         {

--- a/PathfinderAPI/Action/ConditionManager.cs
+++ b/PathfinderAPI/Action/ConditionManager.cs
@@ -15,6 +15,7 @@ namespace Pathfinder.Action
     public static class ConditionManager
     {
         private static readonly Dictionary<string, Type> CustomConditions = new Dictionary<string, Type>();
+        private static readonly Dictionary<Type, string> XmlNames = new Dictionary<Type, string>();
 
         static ConditionManager()
         {
@@ -37,8 +38,11 @@ namespace Pathfinder.Action
         private static void OnPluginUnload(Assembly pluginAsm)
         {
             var allTypes = pluginAsm.GetTypes();
-            foreach (var name in CustomConditions.Where(x => allTypes.Contains(x.Value)).Select(x => x.Key).ToList())
-                CustomConditions.Remove(name);
+            foreach (var entry in CustomConditions.Where(x => allTypes.Contains(x.Value)).ToList())
+            {
+                CustomConditions.Remove(entry.Key);
+                XmlNames.Remove(entry.Value);
+            }
         }
         
         public static void RegisterCondition<T>(string xmlName) where T : PathfinderCondition => RegisterCondition(typeof(T), xmlName);
@@ -47,6 +51,8 @@ namespace Pathfinder.Action
             if (!typeof(PathfinderCondition).IsAssignableFrom(conditionType))
                 throw new ArgumentException("Condition type must inherit from Pathfinder.Action.PathfinderCondition!", nameof(conditionType));
             CustomConditions.Add(xmlName, conditionType);
+            if (!XmlNames.ContainsKey(conditionType))
+                XmlNames.Add(conditionType, xmlName);
         }
 
         public static void UnregisterCondition<T>() where T : PathfinderCondition => UnregisterCondition(typeof(T));
@@ -55,10 +61,29 @@ namespace Pathfinder.Action
             var xmlName = CustomConditions.FirstOrDefault(x => x.Value == conditionType).Key;
             if (xmlName != null)
                 CustomConditions.Remove(xmlName);
+
+            if (XmlNames.ContainsKey(conditionType))
+            {
+                /* TODO: Get next name? */
+                XmlNames.Remove(conditionType);
+            }
         }
         public static void UnregisterCondition(string xmlName)
         {
+            if (!CustomConditions.ContainsKey(xmlName))
+                return;
+            var conditionType = CustomConditions[xmlName];
             CustomConditions.Remove(xmlName);
+            if (XmlNames[conditionType] == xmlName)
+            {
+                /* TODO: Get next name? */
+                XmlNames.Remove(conditionType);
+            }
+        }
+        public static string GetXmlNameFor(Type type)
+        {
+            XmlNames.TryGetValue(type, out string retVal);
+            return retVal;
         }
         
         [HarmonyPrefix]

--- a/PathfinderAPI/Action/PathfinderAction.cs
+++ b/PathfinderAPI/Action/PathfinderAction.cs
@@ -6,8 +6,11 @@ using Pathfinder.Util.XML;
 
 namespace Pathfinder.Action
 {
-    public abstract class PathfinderAction : SerializableAction
+    public abstract class PathfinderAction : SerializableAction, IXmlName
     {
+
+        public string XmlName => ActionManager.GetXmlNameFor(this.GetType()) ?? this.GetType().Name;
+        
         public virtual XElement GetSaveElement()
         {
             return XMLStorageAttribute.WriteToElement(this);

--- a/PathfinderAPI/Action/PathfinderCondition.cs
+++ b/PathfinderAPI/Action/PathfinderCondition.cs
@@ -6,8 +6,10 @@ using Pathfinder.Util.XML;
 
 namespace Pathfinder.Action
 {
-    public abstract class PathfinderCondition : SerializableCondition
+    public abstract class PathfinderCondition : SerializableCondition, IXmlName
     {
+        public string XmlName => ConditionManager.GetXmlNameFor(this.GetType()) ?? this.GetType().Name;
+        
         public virtual XElement GetSaveElement()
         {
             return XMLStorageAttribute.WriteToElement(this);

--- a/PathfinderAPI/Util/XMLStorageAttribute.cs
+++ b/PathfinderAPI/Util/XMLStorageAttribute.cs
@@ -20,13 +20,24 @@ namespace Pathfinder.Util
         }
         
         private const BindingFlags Flags = BindingFlags.Instance | BindingFlags.Public;
-        
+        public static XElement WriteToElement(IXmlName obj)
+        {
+            var element = new XElement(obj.XmlName);
+            WriteElementContent(obj, element);
+            return element;
+        }
+
         public static XElement WriteToElement(object obj)
+        {
+            var element = new XElement(obj.GetType().Name);
+            WriteElementContent(obj, element);
+            return element;
+        }
+        
+        private static void WriteElementContent(object obj, XElement element) 
         {
             var thisType = obj.GetType();
             var attribType = typeof(XMLStorageAttribute);
-
-            var element = new XElement(thisType.Name);
 
             bool hasSetContent = false;
             
@@ -91,8 +102,6 @@ namespace Pathfinder.Util
                     element.SetAttributeValue(propertyInfo.Name, val);
                 }
             }
-
-            return element;
         }
 
         public static void ReadFromElement(ElementInfo info, object obj)
@@ -159,5 +168,10 @@ namespace Pathfinder.Util
                 setMethod.Invoke(obj, new object[] { info.Attributes.GetString(propertyInfo.Name, (string)getMethod.Invoke(obj, null)) });
             }
         }
+    }
+
+    public interface IXmlName
+    {
+        string XmlName { get; }
     }
 }


### PR DESCRIPTION
Permits overriding of Element Names without having to override `GetSaveElement` or similar.
Includes implementation for Conditions and Actions.

Open Issues:
- [x] `{Condition,Action}Manager` currently permit multiple names per type; sort of. The Typed-`Unregister` functions doesn't seem to properly handle this at the moment; this PR ~~doesn't either~~ fixes their behavior.

Conflicts: #95. Depending on which of these PRs lands first, the other can be rebased.