### PR TITLE
Fix custom themes with non-existent background images

### DIFF
--- a/PathfinderAPI/BaseGameFixes/Performance/ThemeCaching.cs
+++ b/PathfinderAPI/BaseGameFixes/Performance/ThemeCaching.cs
@@ -6,6 +6,7 @@ using Hacknet;
 using Hacknet.Effects;
 using Hacknet.Extensions;
 using HarmonyLib;
+using Microsoft.Xna.Framework;
 using Mono.Cecil;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
@@ -218,6 +219,33 @@ namespace Pathfinder.BaseGameFixes.Performance
                 return false;
             });
             c.Emit(OpCodes.Brfalse, afterThemeSwap);
+        }
+
+        [HarmonyILManipulator]
+        [HarmonyPatch(typeof(ThemeManager), nameof(ThemeManager.drawBackgroundImage))]
+        internal static void FixDrawHexGridBackground(ILContext il)
+        {
+            ILCursor c = new ILCursor(il);
+
+            c.GotoNext(MoveType.Before,
+                x => x.MatchLdsfld(AccessTools.Field(typeof(ThemeManager), nameof(ThemeManager.LastLoadedCustomTheme))),
+                x => x.MatchLdfld(AccessTools.Field(typeof(CustomTheme), nameof(CustomTheme.moduleColorBacking)))
+            );
+            c.RemoveRange(2);
+
+            c.EmitDelegate<Func<Color>>(() =>
+                Utils.convertStringToColor(CachedThemes?.BackingListHead?.Value?.ThemeInfo?.Children?.Find(x => x.Name == "moduleColorBacking")?.Content)
+            );
+
+            c.GotoNext(MoveType.Before,
+                x => x.MatchLdsfld(AccessTools.Field(typeof(ThemeManager), nameof(ThemeManager.LastLoadedCustomTheme))),
+                x => x.MatchLdfld(AccessTools.Field(typeof(CustomTheme), nameof(CustomTheme.moduleColorStrong)))
+            );
+            c.RemoveRange(2);
+
+            c.EmitDelegate<Func<Color>>(() =>
+                Utils.convertStringToColor(CachedThemes?.BackingListHead?.Value?.ThemeInfo?.Children?.Find(x => x.Name == "moduleColorStrong")?.Content)
+            );
         }
     }
 }

--- a/PathfinderAPI/Util/CachedCustomTheme.cs
+++ b/PathfinderAPI/Util/CachedCustomTheme.cs
@@ -64,14 +64,16 @@ namespace Pathfinder.Util
             {
                 if (ThemeInfo.Children.TryGetElement("backgroundImagePath", out var imagePath))
                 {
-                    if (imagePath.Content.HasContent() && imagePath.Content.ContentFileExists())
+                    if (imagePath.Content.HasContent())
                     {
-                        using (FileStream imageSteam = File.OpenRead(imagePath.Content.ContentFilePath()))
-                        {
-                            BackgroundImage = Texture2D.FromStream(GuiData.spriteBatch.GraphicsDevice, imageSteam);
-                        }
-
                         Loaded = true;
+                        if (imagePath.Content.ContentFileExists())
+                        {
+                            using (FileStream imageSteam = File.OpenRead(imagePath.Content.ContentFilePath()))
+                            {
+                                BackgroundImage = Texture2D.FromStream(GuiData.spriteBatch.GraphicsDevice, imageSteam);
+                            }
+                        }
                     }
                 }
             }


### PR DESCRIPTION
Should allow themes without valid background image paths to be loaded and "fixes" the animated hex grid that they would display.