### PR TITLE
Migrate over to .Net Core csproj SDK syntax

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
       uses: microsoft/setup-msbuild@v1.0.2
 
     - name: Build Projects
-      run: msbuild /p:Configuration=Release
+      run: msbuild /p:Configuration=Release /p:DisableBepInExHacknetPrepareForBuild=true
 
     - name: Create Release Directory
       run: |

--- a/BepInEx.Hacknet/BepInEx.Hacknet.csproj
+++ b/BepInEx.Hacknet/BepInEx.Hacknet.csproj
@@ -1,51 +1,40 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
+<Project ToolsVersion="16.0" >
+
+  <Import Project="..\Configurations.props" />
+
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.5.5.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\libs\0Harmony.dll</HintPath>
+    <Reference Include="0Harmony, Version=2.5.5.0, Culture=neutral, PublicKeyToken=null" />
+    <Reference Include="BepInEx.Core, Version=6.0.0.423, Culture=neutral, PublicKeyToken=null" />
+    <Reference Include="FNA, Version=17.2.0.0, Culture=neutral, PublicKeyToken=null" Private="False" />
+    <Reference Include="Hacknet, Version=1.0.0.0" Private="False">
+      <HintPath>$(LibsDir)HacknetPathfinder.exe</HintPath>
     </Reference>
-    <Reference Include="BepInEx.Core, Version=6.0.0.423, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\libs\BepInEx.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="FNA, Version=17.2.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\libs\FNA.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Hacknet, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\libs\HacknetPathfinder.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e">
-      <HintPath>..\libs\Mono.Cecil.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Mdb, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e">
-      <HintPath>..\libs\Mono.Cecil.Mdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Pdb, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e">
-      <HintPath>..\libs\Mono.Cecil.Pdb.dll</HintPath>
-    </Reference>
-    <Reference Include="Mono.Cecil.Rocks, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e">
-      <HintPath>..\libs\Mono.Cecil.Rocks.dll</HintPath>
-    </Reference>
-    <Reference Include="MonoMod.RuntimeDetour, Version=21.9.19.1, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\libs\MonoMod.RuntimeDetour.dll</HintPath>
-    </Reference>
-    <Reference Include="MonoMod.Utils, Version=21.9.19.1, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\libs\MonoMod.Utils.dll</HintPath>
-    </Reference>
-    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-      <HintPath>..\libs\Newtonsoft.Json.dll</HintPath>
-    </Reference>
-    <Reference Include="SemanticVersioning, Version=2.0.0.0, Culture=neutral, PublicKeyToken=a89bb7dc6f7a145c">
-      <HintPath>..\libs\SemanticVersioning.dll</HintPath>
-    </Reference>
+    <Reference Include="Mono.Cecil, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e" />
+    <Reference Include="Mono.Cecil.Mdb, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e" />
+    <Reference Include="Mono.Cecil.Pdb, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e" />
+    <Reference Include="Mono.Cecil.Rocks, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e" />
+    <Reference Include="MonoMod.RuntimeDetour, Version=21.9.19.1, Culture=neutral, PublicKeyToken=null" />
+    <Reference Include="MonoMod.Utils, Version=21.9.19.1, Culture=neutral, PublicKeyToken=null" />
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />
+    <Reference Include="SemanticVersioning, Version=2.0.0.0, Culture=neutral, PublicKeyToken=a89bb7dc6f7a145c" />
   </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-  </ItemGroup>
+
+  <Target Name="PrepareForBuild" >
+    <MSBuild Projects="$(PatcherDir)PathfinderPatcher.csproj" />
+    <Exec Condition="$([MSBuild]::IsOSPlatform('Linux'))"
+      Command="chmod +x $(PatcherBinDir)PathfinderPatcher.exe" />
+    <Move Condition="Exists('$(HacknetDir)HacknetPathfinder.exe')"
+      SourceFiles="$(HacknetDir)HacknetPathfinder.exe"
+      DestinationFiles="$(HacknetDir)HacknetPathfinder.exe.temp"
+    />
+    <Exec Command="mono $(PatcherBinDir)PathfinderPatcher.exe" WorkingDirectory="$(HacknetDir)" />
+    <Move
+      SourceFiles="$(HacknetDir)HacknetPathfinder.exe"
+      DestinationFiles="$(LibsDir)HacknetPathfinder.exe"
+    />
+    <Move Condition="Exists('$(HacknetDir)HacknetPathfinder.exe.temp')"
+      SourceFiles="$(HacknetDir)HacknetPathfinder.exe.temp"
+      DestinationFiles="$(HacknetDir)HacknetPathfinder.exe"
+    />
+  </Target>
 </Project>

--- a/BepInEx.Hacknet/BepInEx.Hacknet.csproj
+++ b/BepInEx.Hacknet/BepInEx.Hacknet.csproj
@@ -20,8 +20,10 @@
   </ItemGroup>
 
   <Target Condition=" $(DisableBepInExHacknetPrepareForBuild.ToLower()) != 'true' "
-    Name="PrepareForBuild" >
-    <MSBuild Projects="$(PatcherDir)PathfinderPatcher.csproj" />
+    Name="BepInExPrebuild" BeforeTargets="PrepareForBuild" >
+    <MSBuild Projects="$(PatcherDir)PathfinderPatcher.csproj"
+      Properties="Configuration=$(Configuration)"
+    />
     <Exec Condition="$([MSBuild]::IsOSPlatform('Linux'))"
       Command="chmod +x $(PatcherBinDir)PathfinderPatcher.exe" />
     <Move Condition="Exists('$(HacknetDir)HacknetPathfinder.exe')"

--- a/BepInEx.Hacknet/BepInEx.Hacknet.csproj
+++ b/BepInEx.Hacknet/BepInEx.Hacknet.csproj
@@ -27,7 +27,10 @@
       SourceFiles="$(HacknetDir)HacknetPathfinder.exe"
       DestinationFiles="$(HacknetDir)HacknetPathfinder.exe.temp"
     />
-    <Exec Command="mono $(PatcherBinDir)PathfinderPatcher.exe" WorkingDirectory="$(HacknetDir)" />
+    <Exec Condition="$(OS) == 'Windows_NT' "
+      Command="$(PatcherBinDir)PathfinderPatcher.exe" WorkingDirectory="$(HacknetDir)" />
+    <Exec Condition="$(OS) == 'Unix' "
+      Command="mono $(PatcherBinDir)PathfinderPatcher.exe" WorkingDirectory="$(HacknetDir)" />
     <Move
       SourceFiles="$(HacknetDir)HacknetPathfinder.exe"
       DestinationFiles="$(LibsDir)HacknetPathfinder.exe"

--- a/BepInEx.Hacknet/BepInEx.Hacknet.csproj
+++ b/BepInEx.Hacknet/BepInEx.Hacknet.csproj
@@ -17,6 +17,8 @@
     <Reference Include="MonoMod.Utils, Version=21.9.19.1, Culture=neutral, PublicKeyToken=null" />
     <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" />
     <Reference Include="SemanticVersioning, Version=2.0.0.0, Culture=neutral, PublicKeyToken=a89bb7dc6f7a145c" />
+
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <Target Condition=" $(DisableBepInExHacknetPrepareForBuild.ToLower()) != 'true' "

--- a/BepInEx.Hacknet/BepInEx.Hacknet.csproj
+++ b/BepInEx.Hacknet/BepInEx.Hacknet.csproj
@@ -19,7 +19,8 @@
     <Reference Include="SemanticVersioning, Version=2.0.0.0, Culture=neutral, PublicKeyToken=a89bb7dc6f7a145c" />
   </ItemGroup>
 
-  <Target Name="PrepareForBuild" >
+  <Target Condition=" $(DisableBepInExHacknetPrepareForBuild.ToLower()) != 'true' "
+    Name="PrepareForBuild" >
     <MSBuild Projects="$(PatcherDir)PathfinderPatcher.csproj" />
     <Exec Condition="$([MSBuild]::IsOSPlatform('Linux'))"
       Command="chmod +x $(PatcherBinDir)PathfinderPatcher.exe" />

--- a/Configurations.props
+++ b/Configurations.props
@@ -35,7 +35,7 @@
     <PathfinderSolutionDir>$(MSBuildThisFileDirectory)</PathfinderSolutionDir>
     <LibsDir>$(PathfinderSolutionDir)libs/</LibsDir>
     <PatcherDir>$(PathfinderSolutionDir)PathfinderPatcher/</PatcherDir>
-    <PatcherBinDir>$(PatcherDir)bin/$(Configuration)/$(TargetFramework)/</PatcherBinDir>
+    <PatcherBinDir>$(PatcherDir)bin/$(Configuration)/</PatcherBinDir>
     <AssemblySearchPaths>
     $(AssemblySearchPaths);
     $(LibsDir);

--- a/Configurations.props
+++ b/Configurations.props
@@ -1,0 +1,62 @@
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="16.0">
+
+  <PropertyGroup Label="GetSteamLibraryDir" Condition=" '$(SteamLibraryDir)' == '' ">
+    <SteamLibraryDir Condition=" $([MSBuild]::IsOSPlatform('Windows'))">
+      C:\Program Files (x86)\Steam\steamapps\common\
+    </SteamLibraryDir>
+    <SteamLibraryDir Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+      <!-- Not supported currently -->
+    </SteamLibraryDir>
+    <SteamLibraryDir Condition="$([MSBuild]::IsOSPlatform('Linux'))">
+      $(Home)/.local/share/Steam/steamapps/common/
+    </SteamLibraryDir>
+    <SteamLibraryDir>$(SteamLibraryDir.Trim())</SteamLibraryDir>
+  </PropertyGroup>
+
+  <PropertyGroup Label="GetHacknetDir" Condition=" '$(HacknetDir)' == '' ">
+    <HacknetDir Condition=" $([MSBuild]::IsOSPlatform('Windows'))">
+      $(SteamLibraryDir)Hacknet\
+    </HacknetDir>
+    <HacknetDir Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+      $(SteamLibraryDir)Hacknet/
+    </HacknetDir>
+    <HacknetDir Condition="$([MSBuild]::IsOSPlatform('Linux'))">
+      $(SteamLibraryDir)Hacknet/
+    </HacknetDir>
+    <HacknetDir>$(HacknetDir.Trim())</HacknetDir>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Build">
+    <TargetFramework>net472</TargetFramework>
+    <TargetFrameworkProfile />
+    <LangVersion>10</LangVersion>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
+    <PathfinderSolutionDir>$(MSBuildThisFileDirectory)</PathfinderSolutionDir>
+    <LibsDir>$(PathfinderSolutionDir)libs/</LibsDir>
+    <PatcherDir>$(PathfinderSolutionDir)PathfinderPatcher/</PatcherDir>
+    <PatcherBinDir>$(PatcherDir)bin/$(Configuration)/$(TargetFramework)/</PatcherBinDir>
+    <AssemblySearchPaths>
+    $(AssemblySearchPaths);
+    $(LibsDir);
+    $(HacknetDir);
+    </AssemblySearchPaths>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <DebugType>full</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugType>pdbonly</DebugType>
+  </PropertyGroup>
+
+  <PropertyGroup Label="Package">
+    <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <Version>5.0.0.0</Version>
+    <Copyright>Copyright ©  2021</Copyright>
+  </PropertyGroup>
+
+</Project>

--- a/ExampleMod/ExampleMod.csproj
+++ b/ExampleMod/ExampleMod.csproj
@@ -1,30 +1,76 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <ImplicitUsings>enable</ImplicitUsings>
-  </PropertyGroup>
+<Project Sdk="Microsoft.NET.Sdk" ToolsVersion="16.0">
+
+    <PropertyGroup Label="GetSteamLibraryDir" Condition=" '$(SteamLibraryDir)' == '' ">
+        <SteamLibraryDir Condition=" $([MSBuild]::IsOSPlatform('Windows'))">
+            C:\Program Files (x86)\Steam\steamapps\common\
+        </SteamLibraryDir>
+        <SteamLibraryDir Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+            <!-- Not supported currently -->
+        </SteamLibraryDir>
+        <SteamLibraryDir Condition="$([MSBuild]::IsOSPlatform('Linux'))">
+            $(Home)/.local/share/Steam/steamapps/common/
+        </SteamLibraryDir>
+        <SteamLibraryDir>$(SteamLibraryDir.Trim())</SteamLibraryDir>
+    </PropertyGroup>
+
+    <PropertyGroup Label="GetHacknetDir" Condition=" '$(HacknetDir)' == '' ">
+        <HacknetDir Condition=" $([MSBuild]::IsOSPlatform('Windows'))">
+            $(SteamLibraryDir)Hacknet\
+        </HacknetDir>
+        <HacknetDir Condition="$([MSBuild]::IsOSPlatform('OSX'))">
+            $(SteamLibraryDir)Hacknet/
+        </HacknetDir>
+        <HacknetDir Condition="$([MSBuild]::IsOSPlatform('Linux'))">
+            $(SteamLibraryDir)Hacknet/
+        </HacknetDir>
+        <HacknetDir>$(HacknetDir.Trim())</HacknetDir>
+    </PropertyGroup>
+
+    <PropertyGroup Label="Build">
+        <TargetFramework>net45</TargetFramework>
+        <TargetFrameworkProfile />
+        <LangVersion>8</LangVersion>
+        <AssemblySearchPaths>
+        $(AssemblySearchPaths);
+        ../libs/;
+        $(HacknetDir);
+        </AssemblySearchPaths>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+        <DebugType>full</DebugType>
+    </PropertyGroup>
+
+    <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+        <DebugType>pdbonly</DebugType>
+    </PropertyGroup>
+
+    <PropertyGroup Label="Package">
+        <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
+        <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+        <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+        <Version>5.0.0.0</Version>
+        <Copyright>Copyright ©  2021</Copyright>
+    </PropertyGroup>
+
   <ItemGroup>
-    <ProjectReference Private="false" Include="..\BepInEx.Hacknet\BepInEx.Hacknet.csproj" />
-    <ProjectReference Private="false" Include="..\PathfinderAPI\PathfinderAPI.csproj" />
+    <Reference Include="0Harmony, Version=2.5.5.0, Culture=neutral, PublicKeyToken=null" Private="False" />
+    <Reference Include="BepInEx.Core, Version=6.0.0.423, Culture=neutral, PublicKeyToken=null" Private="False" />
+    <Reference Include="FNA, Version=17.2.0.0, Culture=neutral, PublicKeyToken=null" Private="False" />
+    <Reference Include="Hacknet, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null" Private="False">
+      <HintPath>../libs/HacknetPathfinder.exe</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.5.5.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\libs\0Harmony.dll</HintPath>
+    <ProjectReference Include="..\BepInEx.Hacknet\BepInEx.Hacknet.csproj">
+      <Project>{64faeda5-e87c-47ed-8200-e1de1f263040}</Project>
+      <Name>BepInEx.Hacknet</Name>
       <Private>False</Private>
-    </Reference>
-    <Reference Include="BepInEx.Core, Version=6.0.0.423, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\libs\BepInEx.Core.dll</HintPath>
+    </ProjectReference>
+    <ProjectReference Include="..\PathfinderAPI\PathfinderAPI.csproj">
+      <Project>{4de0a4cf-ec60-46e1-ad96-be3a0f5be406}</Project>
+      <Name>PathfinderAPI</Name>
       <Private>False</Private>
-    </Reference>
-    <Reference Include="FNA, Version=17.2.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\libs\FNA.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Hacknet, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\libs\HacknetPathfinder.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/ExampleMod/ExampleMod.csproj
+++ b/ExampleMod/ExampleMod.csproj
@@ -30,6 +30,7 @@
         <TargetFramework>net472</TargetFramework>
         <TargetFrameworkProfile />
         <LangVersion>10</LangVersion>
+        <ImplicitUsings>enable</ImplicitUsings>
         <AssemblySearchPaths>
         $(AssemblySearchPaths);
         ../libs/;

--- a/ExampleMod/ExampleMod.csproj
+++ b/ExampleMod/ExampleMod.csproj
@@ -27,9 +27,9 @@
     </PropertyGroup>
 
     <PropertyGroup Label="Build">
-        <TargetFramework>net45</TargetFramework>
+        <TargetFramework>net472</TargetFramework>
         <TargetFrameworkProfile />
-        <LangVersion>8</LangVersion>
+        <LangVersion>10</LangVersion>
         <AssemblySearchPaths>
         $(AssemblySearchPaths);
         ../libs/;

--- a/PathfinderAPI/PathfinderAPI.csproj
+++ b/PathfinderAPI/PathfinderAPI.csproj
@@ -15,6 +15,8 @@
     </Reference>
     <Reference Include="Mono.Cecil, Version=0.11.4.0" Private="False" />
     <Reference Include="MonoMod.Utils, Version=21.9.19.1" Private="False" />
+
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 
   <ItemGroup>

--- a/PathfinderAPI/PathfinderAPI.csproj
+++ b/PathfinderAPI/PathfinderAPI.csproj
@@ -1,41 +1,27 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project ToolsVersion="16.0">
+
+  <Import Project="..\Configurations.props" />
+
   <PropertyGroup>
-    <TargetFramework>net472</TargetFramework>
-    <LangVersion>latest</LangVersion>
     <RootNamespace>Pathfinder</RootNamespace>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
   <ItemGroup>
-    <Reference Include="0Harmony, Version=2.5.5.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\libs\0Harmony.dll</HintPath>
-      <Private>False</Private>
+    <Reference Include="0Harmony, Version=2.5.5.0" Private="False" />
+    <Reference Include="BepInEx.Core, Version=6.0.0.423" Private="False" />
+    <Reference Include="FNA, Version=17.2.0.0" Private="False" />
+    <Reference Include="Hacknet, Version=1.0.0.0" Private="False">
+      <HintPath>$(LibsDir)HacknetPathfinder.exe</HintPath>
     </Reference>
-    <Reference Include="BepInEx.Core, Version=6.0.0.423, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\libs\BepInEx.Core.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="FNA, Version=17.2.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\libs\FNA.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Hacknet, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\libs\HacknetPathfinder.exe</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="Mono.Cecil, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e">
-      <HintPath>..\libs\Mono.Cecil.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="MonoMod.Utils, Version=21.9.19.1, Culture=neutral, PublicKeyToken=null">
-      <HintPath>..\libs\MonoMod.Utils.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
+    <Reference Include="Mono.Cecil, Version=0.11.4.0" Private="False" />
+    <Reference Include="MonoMod.Utils, Version=21.9.19.1" Private="False" />
   </ItemGroup>
+
   <ItemGroup>
-    <ProjectReference Private="false" Include="..\BepInEx.Hacknet\BepInEx.Hacknet.csproj" />
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <ProjectReference Include="$(PathfinderSolutionDir)BepInEx.Hacknet\BepInEx.Hacknet.csproj" Private="False">
+      <Project>{64faeda5-e87c-47ed-8200-e1de1f263040}</Project>
+      <Name>BepInEx.Hacknet</Name>
+      <Private>False</Private>
+    </ProjectReference>
   </ItemGroup>
 </Project>

--- a/PathfinderPatcher/PathfinderPatcher.csproj
+++ b/PathfinderPatcher/PathfinderPatcher.csproj
@@ -1,17 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-  <PropertyGroup>
+﻿<Project ToolsVersion="16.0">
+
+  <PropertyGroup Label="Build">
     <OutputType>Exe</OutputType>
-    <TargetFramework>net472</TargetFramework>
-    <LangVersion>latest</LangVersion>
-    <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-    <ImplicitUsings>enable</ImplicitUsings>
   </PropertyGroup>
+
+  <Import Project="..\Configurations.props" />
+
   <ItemGroup>
-    <Reference Include="Mono.Cecil, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e">
-      <HintPath>..\libs\Mono.Cecil.dll</HintPath>
-    </Reference>
-  </ItemGroup>
-  <ItemGroup>
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
+    <Reference Include="Mono.Cecil, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e" />
   </ItemGroup>
 </Project>

--- a/PathfinderPatcher/PathfinderPatcher.csproj
+++ b/PathfinderPatcher/PathfinderPatcher.csproj
@@ -8,5 +8,7 @@
 
   <ItemGroup>
     <Reference Include="Mono.Cecil, Version=0.11.4.0, Culture=neutral, PublicKeyToken=50cebf1cceb9d05e" />
+
+    <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
 </Project>

--- a/PathfinderUpdater/PathfinderUpdater.csproj
+++ b/PathfinderUpdater/PathfinderUpdater.csproj
@@ -13,8 +13,9 @@
         <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" Private="False" />
         <Reference Include="SemanticVersioning, Version=2.0.0.0, Culture=neutral, PublicKeyToken=a89bb7dc6f7a145c"  Private="False" />
         <Reference Include="System.Configuration" />
-        <Reference Include="System.Net.Http" />
         <Reference Include="System.IO.Compression" />
+
+        <PackageReference Include="System.Net.Http" Version="4.3.4" />
     </ItemGroup>
     <ItemGroup>
       <ProjectReference Include="$(PathfinderSolutionDir)BepInEx.Hacknet\BepInEx.Hacknet.csproj">

--- a/PathfinderUpdater/PathfinderUpdater.csproj
+++ b/PathfinderUpdater/PathfinderUpdater.csproj
@@ -1,43 +1,39 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-    <PropertyGroup>
-        <TargetFramework>net472</TargetFramework>
-        <LangVersion>latest</LangVersion>
-        <AppendTargetFrameworkToOutputPath>false</AppendTargetFrameworkToOutputPath>
-        <ImplicitUsings>enable</ImplicitUsings>
-    </PropertyGroup>
+﻿<Project ToolsVersion="16.0" DefaultTargets="Build">
+
+    <Import Project="..\Configurations.props" />
+
     <ItemGroup>
-      <ProjectReference Private="false" Include="..\BepInEx.Hacknet\BepInEx.Hacknet.csproj" />
-      <ProjectReference Private="false" Include="..\PathfinderAPI\PathfinderAPI.csproj" />
+        <Reference Include="0Harmony, Version=2.5.5.0, Culture=neutral, PublicKeyToken=null" Private="False" />
+        <Reference Include="BepInEx.Core, Version=6.0.0.423, Culture=neutral, PublicKeyToken=null" Private="False" />
+        <Reference Include="FNA, Version=17.2.0.0, Culture=neutral, PublicKeyToken=null" Private="False" />
+        <Reference Include="Hacknet, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+          <HintPath>$(LibsDir)HacknetPathfinder.exe</HintPath>
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed" Private="False" />
+        <Reference Include="SemanticVersioning, Version=2.0.0.0, Culture=neutral, PublicKeyToken=a89bb7dc6f7a145c"  Private="False" />
+        <Reference Include="System.Configuration" />
+        <Reference Include="System.Net.Http" />
+        <Reference Include="System.IO.Compression" />
     </ItemGroup>
     <ItemGroup>
-      <Reference Include="0Harmony, Version=2.5.5.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>..\libs\0Harmony.dll</HintPath>
+      <ProjectReference Include="$(PathfinderSolutionDir)BepInEx.Hacknet\BepInEx.Hacknet.csproj">
+        <Project>{64faeda5-e87c-47ed-8200-e1de1f263040}</Project>
+        <Name>BepInEx.Hacknet</Name>
         <Private>False</Private>
-      </Reference>
-      <Reference Include="BepInEx.Core, Version=6.0.0.423, Culture=neutral, PublicKeyToken=null">
-        <HintPath>..\libs\BepInEx.Core.dll</HintPath>
+      </ProjectReference>
+      <ProjectReference Include="$(PathfinderSolutionDir)PathfinderAPI\PathfinderAPI.csproj">
+        <Project>{4de0a4cf-ec60-46e1-ad96-be3a0f5be406}</Project>
+        <Name>PathfinderAPI</Name>
         <Private>False</Private>
-      </Reference>
-      <Reference Include="FNA, Version=17.2.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>..\libs\FNA.dll</HintPath>
-        <Private>False</Private>
-      </Reference>
-      <Reference Include="Hacknet, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-        <HintPath>..\libs\HacknetPathfinder.exe</HintPath>
-        <Private>False</Private>
-      </Reference>
-      <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed">
-        <HintPath>..\libs\Newtonsoft.Json.dll</HintPath>
-        <Private>False</Private>
-      </Reference>
-      <Reference Include="SemanticVersioning, Version=2.0.0.0, Culture=neutral, PublicKeyToken=a89bb7dc6f7a145c">
-        <HintPath>..\libs\SemanticVersioning.dll</HintPath>
-        <Private>False</Private>
-      </Reference>
+      </ProjectReference>
     </ItemGroup>
-    <ItemGroup>
-      <PackageReference Include="System.Configuration.ConfigurationManager" Version="6.0.0" />
-      <PackageReference Include="System.IO.Compression" Version="4.3.0" />
-      <PackageReference Include="System.Net.Http" Version="4.3.4" />
-    </ItemGroup>
+    <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
+         Other similar extension points exist, see Microsoft.Common.targets.
+    <Target Name="BeforeBuild">
+    </Target>
+    <Target Name="AfterBuild">
+    </Target>
+    -->
+
 </Project>

--- a/README.md
+++ b/README.md
@@ -57,11 +57,13 @@ Install the mod by placing it in Hacknet/BepInEx/plugins or a folder called Plug
 ## Contributing to Pathfinder
 
 1. Clone the project with `git clone https://github.com/Arkhist/Hacknet-Pathfinder` or preferably fork it and clone that repo so you can pull request
-2. Compile PathfinderPatcher and run it in the Hacknet directory
-3. Copy HacknetPathfinder.exe and FNA.dll to the libs/ directory
-4. Everything else should now compile fine
-5. Everything in BepInEx.Hacknet/bin/Debug goes into Hacknet/BepInEx/core.
-6. Copy/symlink the .dll (or their containing folder) for PathfinderAPI and optionally ExampleMod to Hacknet/BepInEx/plugins
+2. Compile PathfinderAPI or BepInEx.Hacknet
+
+### Testing contiburitons
+
+1. Copy libs/HacknetPathfinder.exe over to the Hacknet directory
+2. Everything in BepInEx.Hacknet/bin/Debug goes into Hacknet/BepInEx/core.
+3. Copy/symlink the .dll (or their containing folder) for PathfinderAPI and optionally ExampleMod to Hacknet/BepInEx/plugins
 
 ## Links
 


### PR DESCRIPTION
Added SteamLibraryDir, HacknetDir, PathfinderSolutionDir, PatcherDir, PatcherBinDir, and LibsDir for reduced reliance on relative paths
Reduced necessary explicit project properties
Replace pre-generated AssemblyInfo with build generated AssemblyInfo
Added PrepareForBuild task for BepInEx.Hacknet which:
	- Builds PathfinderPatcher
	- If on Linux, executes chmod +x on PathfinderPatcher.exe
	- If HacknetPathfinder.exe is found in HacknetDir, rename it to a temp file
	- Execute mono PathfinderPatcher.exe in HacknetDir
	- Move HacknetPathfinder.exe to LibsDir
	- If temp file is found, rename HacknetPathfinder.exe back
Sanitized a few discrepant indentations in PathfinderUpdater.csproj