### PR TITLE
Fix loading plugin dependencies that were renamed by ChainloaderFix.PluginCecilHacks

### DIFF
--- a/BepInEx.Hacknet/Entrypoint.cs
+++ b/BepInEx.Hacknet/Entrypoint.cs
@@ -45,33 +45,30 @@ namespace BepInEx.Hacknet
         {
             var asmName = new AssemblyName(args.Name);
 
-            foreach (var path in Directory
-                .GetFiles($"/usr/lib/mono/gac/{asmName.Name}", $"{asmName.Name}.dll", SearchOption.AllDirectories)
-                .Select(Path.GetFullPath))
+            try
             {
-                try
+                foreach (var path in Directory
+                    .GetFiles($"/usr/lib/mono/gac/{asmName.Name}", $"{asmName.Name}.dll", SearchOption.AllDirectories)
+                    .Select(Path.GetFullPath))
                 {
-                    return Assembly.LoadFile(path);
+                    try
+                    {
+                        return Assembly.LoadFile(path);
+                    }
+                    catch { }
                 }
-                catch {}
             }
+            catch { }
 
             return null;
         }
 
         public static Assembly ResolveRenamedAssembly(object sender, ResolveEventArgs args)
         {
-            HacknetChainloader.Instance.Log.LogInfo("ResolveRenamedAssembly : Attempting resolve");
-            HacknetChainloader.Instance.Log.LogInfo("ResolveRenamedAssembly : args.Name = " + args.Name);
-
             var asmName = new AssemblyName(args.Name);
-
-            HacknetChainloader.Instance.Log.LogInfo("ResolveRenamedAssembly : asmName.Name " + asmName.Name);
 
             if (ChainloaderFix.Remaps.TryGetValue(asmName.Name, out Assembly ret))
                 return ret;
-
-            HacknetChainloader.Instance.Log.LogInfo("ResolveRenamedAssembly : Could not find assembly.");
 
             return null;
         }

--- a/BepInEx.Hacknet/HacknetChainloader.cs
+++ b/BepInEx.Hacknet/HacknetChainloader.cs
@@ -95,8 +95,6 @@ namespace BepInEx.Hacknet
             TemporaryPluginGUIDs.Clear();
             ChainloaderFix.Remaps.Clear();
 
-            Log.LogInfo("UnloadTemps : Assembly remaps cleared.");
-
             Log.LogMessage("Finished unloading extension plugins");
         }
     }
@@ -203,8 +201,6 @@ namespace BepInEx.Hacknet
                     name = asm.Name.Name;
                     asm.Name.Name = asm.Name.Name + "-" + DateTime.Now.Ticks;
 
-                    HacknetChainloader.Instance.Log.LogInfo("PluginCecilHacks : Added remap " + name + " -> " + asm.Name.Name);
-
                     using (var ms = new MemoryStream())
                     {
                         asm.Write(ms);
@@ -215,8 +211,6 @@ namespace BepInEx.Hacknet
 
                 var loaded = Assembly.Load(asmBytes);
                 Remaps[name] = loaded;
-
-                HacknetChainloader.Instance.Log.LogInfo("PluginCecilHacks : Assembly loaded from bytes.");
 
                 return loaded;
             });


### PR DESCRIPTION
Keeps track of renamed assemblies in a Dictionary until the extension is quit.