### PR TITLE
Added RegisterExecutor(Type, string, ParseOption) for ContentLoader, ExtensionInfoLoader, MissionLoader, and SaveLoader

### DIFF
--- a/PathfinderAPI/Replacements/ContentLoader.cs
+++ b/PathfinderAPI/Replacements/ContentLoader.cs
@@ -57,12 +57,19 @@ namespace Pathfinder.Replacements
         
         private static readonly List<ComputerExecutorHolder> CustomExecutors = new List<ComputerExecutorHolder>();
 
-        public static void RegisterExecutor<T>(string element, ParseOption options = ParseOption.None) where T : ComputerExecutor, new()
+        public static void RegisterExecutor<T>(string element, ParseOption options = ParseOption.None) where T : ComputerExecutor, new() => RegisterExecutor(typeof(T), element, options);
+        public static void RegisterExecutor(Type executorType, string element, ParseOption options = ParseOption.None)
         {
+            if (!typeof(ComputerExecutor).IsAssignableFrom(executorType))
+                throw new ArgumentException("Type of executor registered must inherit from Pathfinder.Replacements.ContentLoader.ComputerExecutor!", nameof(executorType));
+
+            if(!executorType.GetConstructors().Any(ctor => ctor.GetParameters().Length == 0))
+                throw new ArgumentException("Type of executor registered must have a default constructor", nameof(executorType));
+
             CustomExecutors.Add(new ComputerExecutorHolder
             {
                 Element = element,
-                ExecutorType = typeof(T),
+                ExecutorType = executorType,
                 Options = options
             });
         }

--- a/PathfinderAPI/Replacements/ExtensionInfoLoader.cs
+++ b/PathfinderAPI/Replacements/ExtensionInfoLoader.cs
@@ -44,13 +44,20 @@ namespace Pathfinder.Replacements
         public static void AddLanguage(string language) => ValidLanguages.Add(language);
         
         private static readonly List<ExtensionInfoExecutorHolder> CustomExecutors = new List<ExtensionInfoExecutorHolder>();
-        
-        public static void RegisterExecutor<T>(string element, ParseOption options = ParseOption.None) where T : ExtensionInfoExecutor, new()
+
+        public static void RegisterExecutor<T>(string element, ParseOption options = ParseOption.None) where T : ExtensionInfoExecutor, new() => RegisterExecutor(typeof(T), element, options);
+        public static void RegisterExecutor(Type executorType, string element, ParseOption options = ParseOption.None)
         {
+            if (!typeof(ExtensionInfoExecutor).IsAssignableFrom(executorType))
+                throw new ArgumentException("Type of executor registered must inherit from Pathfinder.Replacements.ExtensionInfoLoader.ExtensionInfoExecutor!", nameof(executorType));
+
+            if(!executorType.GetConstructors().Any(ctor => ctor.GetParameters().Length == 0))
+                throw new ArgumentException("Type of executor registered must have a default constructor", nameof(executorType));
+
             CustomExecutors.Add(new ExtensionInfoExecutorHolder
             {
                 Element = element,
-                ExecutorType = typeof(T),
+                ExecutorType = executorType,
                 Options = options
             });
         }

--- a/PathfinderAPI/Replacements/MissionLoader.cs
+++ b/PathfinderAPI/Replacements/MissionLoader.cs
@@ -39,12 +39,19 @@ namespace Pathfinder.Replacements
         
         private static readonly List<MissionExecutorHolder> CustomExecutors = new List<MissionExecutorHolder>();
 
-        public static void RegisterExecutor<T>(string element, ParseOption options = ParseOption.None) where T : MissionExecutor, new()
+        public static void RegisterExecutor<T>(string element, ParseOption options = ParseOption.None) where T : MissionExecutor, new() => RegisterExecutor(typeof(T), element, options);
+        public static void RegisterExecutor(Type executorType, string element, ParseOption options = ParseOption.None)
         {
+            if (!typeof(MissionExecutor).IsAssignableFrom(executorType))
+                throw new ArgumentException("Type of executor registered must inherit from Pathfinder.Replacements.MissionLoader.MissionExecutor!", nameof(executorType));
+
+            if(!executorType.GetConstructors().Any(ctor => ctor.GetParameters().Length == 0))
+                throw new ArgumentException("Type of executor registered must have a default constructor", nameof(executorType));
+
             CustomExecutors.Add(new MissionExecutorHolder
             {
                 Element = element,
-                ExecutorType = typeof(T),
+                ExecutorType = executorType,
                 Options = options
             });
         }

--- a/PathfinderAPI/Replacements/SaveLoader.cs
+++ b/PathfinderAPI/Replacements/SaveLoader.cs
@@ -44,12 +44,19 @@ namespace Pathfinder.Replacements
         
         private static readonly List<SaveExecutorHolder> CustomExecutors = new List<SaveExecutorHolder>();
 
-        public static void RegisterExecutor<T>(string element, ParseOption options = ParseOption.None) where T : SaveExecutor, new()
+        public static void RegisterExecutor<T>(string element, ParseOption options = ParseOption.None) where T : SaveExecutor, new() => RegisterExecutor(typeof(T), element, options);
+        public static void RegisterExecutor(Type executorType, string element, ParseOption options = ParseOption.None)
         {
+            if (!typeof(SaveExecutor).IsAssignableFrom(executorType))
+                throw new ArgumentException("Type of executor registered must inherit from Pathfinder.Replacements.SaveLoader.SaveExecutor!", nameof(executorType));
+
+            if(!executorType.GetConstructors().Any(ctor => ctor.GetParameters().Length == 0))
+                throw new ArgumentException("Type of executor registered must have a default constructor", nameof(executorType));
+
             CustomExecutors.Add(new SaveExecutorHolder
             {
                 Element = element,
-                ExecutorType = typeof(T),
+                ExecutorType = executorType,
                 Options = options
             });
         }


### PR DESCRIPTION
Redirected RegisterExecutor<T>(string, ParseOption) to call the runtime type version
Added consistent safety checks for RegisterExecutor(Type, string, ParseOption)