### PR TITLE
PFPorts Xml implementation

### DIFF
--- a/PathfinderAPI/Port/PortManager.cs
+++ b/PathfinderAPI/Port/PortManager.cs
@@ -107,7 +107,6 @@ namespace Pathfinder.Port
                 var record = GetPortRecordFromProtocol(protocol);
                 int portNum = -1;
                 if(record == null) {
-
                     if(portNumString == null || displayName == null)
                         throw new ArgumentException($"Protocol '{protocol}' does not exist");
 
@@ -116,7 +115,7 @@ namespace Pathfinder.Port
 
                     PortManager.RegisterPort(protocol, displayName, portNum);
                 }
-                else if (!int.TryParse(portNumString, out portNum))
+                else if (portNumString != null && !int.TryParse(portNumString, out portNum))
                     throw new FormatException($"Unable to parse port number for protocol '{protocol}'");
 
                 var state = comp.GetPortState(protocol);

--- a/PathfinderAPI/Port/PortManager.cs
+++ b/PathfinderAPI/Port/PortManager.cs
@@ -121,8 +121,10 @@ namespace Pathfinder.Port
                 var state = comp.GetPortState(protocol);
                 if(state != null)
                 {
-                    state.DisplayName = displayName;
-                    state.PortNumber = portNum;
+                    if(displayName != null)
+                        state.DisplayName = displayName;
+                    if(portNumString != null)
+                        state.PortNumber = portNum;
                     continue;
                 }
 

--- a/PathfinderAPI/Replacements/ContentLoader.cs
+++ b/PathfinderAPI/Replacements/ContentLoader.cs
@@ -327,7 +327,10 @@ namespace Pathfinder.Replacements
             }, ParseOption.ParseInterior);
             executor.RegisterExecutor("Computer.PFPorts", (exec, info) =>
             {
-                PortManager.LoadPortsFromString(comp, info.Content, info.Attributes.GetBool("replace"));
+                if(info.Children.Count != 0)
+                    PortManager.LoadPortsFromChildren(comp, info.Children, info.Attributes.GetBool("replace"));
+                else
+                    PortManager.LoadPortsFromString(comp, info.Content, info.Attributes.GetBool("replace"));
             }, ParseOption.ParseInterior);
             executor.RegisterExecutor("Computer.ExternalCounterpart", (exec, info) =>
             {
@@ -899,7 +902,7 @@ namespace Pathfinder.Replacements
 
             if (!ComputerExtensions.HasInitializedPorts(ret))
             {
-                PortManager.LoadPortsFromString(ret, "ssh ftp smtp web", false);
+                PortManager.LoadPortsFromChildren(ret, ReplacementsCommon.defaultPorts, false);
             }
 
             if (!preventInitDaemons)

--- a/PathfinderAPI/Replacements/ReplacementsCommon.cs
+++ b/PathfinderAPI/Replacements/ReplacementsCommon.cs
@@ -109,13 +109,21 @@ namespace Pathfinder.Replacements
 
         internal static bool isPathfinderComputer = false;
 
+        internal static readonly List<ElementInfo> defaultPorts = new List<ElementInfo>
+        {
+            new ElementInfo() { Name = "ssh" },
+            new ElementInfo() { Name = "ftp" },
+            new ElementInfo() { Name = "smtp" },
+            new ElementInfo() { Name = "web" }
+        };
+
         [HarmonyPostfix]
         [HarmonyPatch(typeof(Computer), MethodType.Constructor, new Type[] { typeof(string), typeof(string), typeof(Vector2), typeof(int), typeof(byte), typeof(OS) })]
         private static void LoadDefaultPortsIfReplacement(Computer __instance)
         {
             if (!isPathfinderComputer)
             {
-                PortManager.LoadPortsFromString(__instance, "ssh ftp smtp web", false);
+                PortManager.LoadPortsFromChildren(__instance, defaultPorts, false);
             }
         }
     }

--- a/PathfinderAPI/Replacements/ReplacementsCommon.cs
+++ b/PathfinderAPI/Replacements/ReplacementsCommon.cs
@@ -111,10 +111,10 @@ namespace Pathfinder.Replacements
 
         internal static readonly List<ElementInfo> defaultPorts = new List<ElementInfo>
         {
-            new ElementInfo() { Name = "ssh" },
-            new ElementInfo() { Name = "ftp" },
+            new ElementInfo() { Name = "web" },
             new ElementInfo() { Name = "smtp" },
-            new ElementInfo() { Name = "web" }
+            new ElementInfo() { Name = "ftp" },
+            new ElementInfo() { Name = "ssh" }
         };
 
         [HarmonyPostfix]

--- a/PathfinderAPI/Replacements/SaveLoader.cs
+++ b/PathfinderAPI/Replacements/SaveLoader.cs
@@ -270,10 +270,49 @@ namespace Pathfinder.Replacements
 
             if (info.Children.TryGetElement("ports", out var ports))
             {
-                foreach (var port in ports.Content.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries))
+                if (ports.Content != null)
+                    foreach (var port in ports.Content.Split(new char[] { ' ' }, StringSplitOptions.RemoveEmptyEntries))
+                    {
+                        var parts = port.Split(':');
+                        var record = PortManager.GetPortRecordFromProtocol(parts[0]);
+                        var displayName = parts[3].Replace('_', ' ');
+                        var portNum = int.Parse(parts[2]);
+                        if(record == null)
+                        {
+                            PortManager.RegisterPort(record = new PortRecord(
+                                parts[0],
+                                displayName,
+                                portNum,
+                                int.Parse(parts[1])
+                            ));
+                        }
+
+                        comp.AddPort(record.CreateState(
+                            comp,
+                            displayName,
+                            portNum
+                        ));
+                    }
+
+                foreach (var port in ports.Children)
                 {
-                    var parts = port.Split(':');
-                    comp.AddPort(new PortRecord(parts[0], parts[3].Replace('_', ' '), int.Parse(parts[2]), int.Parse(parts[1])));
+                    var record = PortManager.GetPortRecordFromProtocol(port.Name);
+                    var displayName = port.Children.GetElement("Display").Content;
+                    var portNum = int.Parse(port.Children.GetElement("Number").Content);
+                    if(record == null)
+                    {
+                        PortManager.RegisterPort(record = new PortRecord(
+                            port.Name,
+                            displayName,
+                            portNum,
+                            int.Parse(port.Children.GetElement("Original").Content)
+                        ));
+                    }
+                    comp.AddPort(record.CreateState(
+                        comp,
+                        displayName,
+                        portNum
+                    ));
                 }
             }
 

--- a/PathfinderAPI/Replacements/SaveWriter.cs
+++ b/PathfinderAPI/Replacements/SaveWriter.cs
@@ -182,12 +182,15 @@ namespace Pathfinder.Replacements
         internal static XElement GetPortSaveElement(Computer node)
         {
             var result = new XElement("ports");
-            var builder = new StringBuilder();
             foreach (var port in node.GetAllPortStates())
             {
-                builder.Append($"{port.Record.Protocol}:{port.Record.OriginalPortNumber}:{port.PortNumber}:{port.DisplayName.Replace(' ', '_')} ");
+                result.Add(
+                    new XElement(port.Record.Protocol,
+                        new XElement("Original", port.Record.OriginalPortNumber),
+                        new XElement("Number", port.PortNumber),
+                        new XElement("Display", port.DisplayName)
+                ));
             }
-            result.Value = builder.ToString();
             return result;
         }
 

--- a/PathfinderAPI/Util/XML/ElementInfo.cs
+++ b/PathfinderAPI/Util/XML/ElementInfo.cs
@@ -11,22 +11,11 @@ namespace Pathfinder.Util.XML
         private static ulong freeId = 0;
         
         public string Name { get; set; }
-        
-        private string content = null;
-        private bool processedContent = false;
-        public string Content
-        {
-            get
-            {
-                return processedContent ? content : throw new InvalidOperationException("");
-            }
-            set
-            {
-                processedContent = true;
-                content = value;
-            }
-        }
-
+        public string Content {
+            get;
+            [Obsolete("Do not use, will become internal")]
+            set;
+        } = null;
         public ElementInfo Parent { get; set; }
         public Dictionary<string, string> Attributes { get; set; } = new Dictionary<string, string>();
         public List<ElementInfo> Children { get; set; } = new List<ElementInfo>();

--- a/PathfinderAPI/Util/XML/EventExecutor.cs
+++ b/PathfinderAPI/Util/XML/EventExecutor.cs
@@ -160,6 +160,7 @@ namespace Pathfinder.Util.XML
             TemporaryExecutors[element].Add(new ExecutorHolder {Executor = executor, Options = options});
         }
 
+#pragma warning disable 618
         protected override void ReadElement(Dictionary<string, string> attributes)
         {
             base.ReadElement(attributes);


### PR DESCRIPTION
Resolves #123 
Added PortManager.LoadPortsFromChildren: Loads from IEnumerable<ElementInfo>
Convert almost every PortManager.LoadPortsFromString call to LoadPortsFromChildren
ContentLoader, SaveLoader, and SaveWriter use new format
SaveLoader preserves old format for now
ReplacementsCommon.LoadDefaultPortsIfReplacement uses LoadPortsFromChildren
Added ReplacementsCommon.defaultPorts
Removed ElementInfo.Content getter exception throw, setter Obsolete for future internal access
Disabled warning 618 (Obsolete) in EventExecutor for ElementInfo.Content setter