### PR TITLE
PostLoad and Load Events

### DIFF
--- a/BepInEx.Hacknet/HacknetChainloader.cs
+++ b/BepInEx.Hacknet/HacknetChainloader.cs
@@ -78,13 +78,20 @@ namespace BepInEx.Hacknet
             return pluginInstance;
         }
 
+        public override void Execute()
+        {
+            base.Execute();
+            foreach(var p in Plugins)
+                ((HacknetPlugin)p.Value.Instance).PostLoad();
+        }
+
         internal void UnloadTemps()
         {
             Log.LogMessage("Unloading extension plugins...");
             
             foreach (var temp in TemporaryPluginGUIDs)
             {
-                if (!(this.Plugins[temp].Instance as HacknetPlugin)?.Unload() ?? true)
+                if (!((HacknetPlugin)this.Plugins[temp].Instance).Unload())
                 {
                     Log.LogError($"{temp} failed to unload, this could cause problems without a game restart!");
                 }

--- a/BepInEx.Hacknet/HacknetPlugin.cs
+++ b/BepInEx.Hacknet/HacknetPlugin.cs
@@ -25,6 +25,11 @@ namespace BepInEx.Hacknet
 
         public abstract bool Load();
 
+        /// <summary>
+        /// Runs after all plugins have executed thier Load method
+        /// </summary>
+        public virtual void PostLoad() {}
+
         public virtual bool Unload()
         {
             HarmonyInstance.UnpatchSelf();

--- a/PathfinderAPI/Event/BepInEx/LoadEvent.cs
+++ b/PathfinderAPI/Event/BepInEx/LoadEvent.cs
@@ -1,0 +1,18 @@
+using System.Reflection;
+using BepInEx.Hacknet;
+using HarmonyLib;
+
+namespace Pathfinder.Event.BepInEx
+{
+    [HarmonyPatch]
+    public class LoadEvent : PathfinderEvent
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(HacknetChainloader), nameof(HacknetChainloader.LoadPlugin))]
+        private static void OnPluginLoad(ref HacknetChainloader __instance, ref HacknetPlugin __result, Assembly pluginAssembly)
+        {
+            var evt = new LoadEvent();
+            EventManager<LoadEvent>.InvokeAssembly(pluginAssembly, evt);
+        }
+    }
+}

--- a/PathfinderAPI/Event/BepInEx/PostLoadEvent.cs
+++ b/PathfinderAPI/Event/BepInEx/PostLoadEvent.cs
@@ -1,0 +1,17 @@
+using BepInEx.Hacknet;
+using HarmonyLib;
+
+namespace Pathfinder.Event.BepInEx
+{
+    [HarmonyPatch]
+    public class PostLoadEvent : PathfinderEvent
+    {
+        [HarmonyPostfix]
+        [HarmonyPatch(typeof(HacknetPlugin), nameof(HacknetPlugin.PostLoad))]
+        private static void OnPluginPostLoad(ref HacknetPlugin __instance)
+        {
+            var evt = new PostLoadEvent();
+            EventManager<PostLoadEvent>.InvokeAssembly(__instance.GetType().Assembly, evt);
+        }
+    }
+}

--- a/PathfinderAPI/Event/BepInEx/UnloadEvent.cs
+++ b/PathfinderAPI/Event/BepInEx/UnloadEvent.cs
@@ -1,0 +1,17 @@
+using BepInEx.Hacknet;
+using HarmonyLib;
+
+namespace Pathfinder.Event.BepInEx
+{
+    [HarmonyPatch]
+    public class UnloadEvent : PathfinderEvent
+    {
+        [HarmonyPrefix]
+        [HarmonyPatch(typeof(HacknetPlugin), nameof(HacknetPlugin.Unload))]
+        private static void OnPluginUnload(ref HacknetPlugin __instance)
+        {
+            var evt = new UnloadEvent();
+            EventManager<UnloadEvent>.InvokeAssembly(__instance.GetType().Assembly, evt);
+        }
+    }
+}

--- a/PathfinderAPI/Event/EventManager.cs
+++ b/PathfinderAPI/Event/EventManager.cs
@@ -158,14 +158,14 @@ namespace Pathfinder.Event
             return eventArgs;
         }
 
-        internal static T InvokeAll(T eventArgs)
+        public static T InvokeAll(T eventArgs)
         {
             var allHandlers = Instance.handlers.AllItems.ToList();
             allHandlers.Sort();
             return InvokeOn(allHandlers, eventArgs);
         }
 
-        internal static T InvokeAssembly(Assembly asm, T eventArgs)
+        public static T InvokeAssembly(Assembly asm, T eventArgs)
         {
             var asmHandlers = Instance.handlers[asm].ToList();
             asmHandlers.Sort();

--- a/PathfinderAPI/Event/EventManager.cs
+++ b/PathfinderAPI/Event/EventManager.cs
@@ -139,11 +139,9 @@ namespace Pathfinder.Event
             handlers.RemoveAssembly(pluginAsm, out _);
         }
 
-        internal static T InvokeAll(T eventArgs)
+        private static T InvokeOn(IEnumerable<EventHandler<T>> list, T eventArgs)
         {
-            var allHandlers = Instance.handlers.AllItems.ToList();
-            allHandlers.Sort();
-            foreach (var handler in allHandlers)
+            foreach (var handler in list)
             {
                 try
                 {
@@ -152,13 +150,26 @@ namespace Pathfinder.Event
                 }
                 catch (Exception e)
                 {
-                    Logger.Log(BepInEx.Logging.LogLevel.Error, $"{handler.HandlerInfo.DeclaringType.FullName}::{handler.HandlerInfo.FullDescription()}");
-                    Logger.Log(BepInEx.Logging.LogLevel.Error, e);
+                    Logger.Log(global::BepInEx.Logging.LogLevel.Error, $"{handler.HandlerInfo.DeclaringType.FullName}::{handler.HandlerInfo.FullDescription()}");
+                    Logger.Log(global::BepInEx.Logging.LogLevel.Error, e);
                     eventArgs.Thrown = true;
                 }
             }
-
             return eventArgs;
+        }
+
+        internal static T InvokeAll(T eventArgs)
+        {
+            var allHandlers = Instance.handlers.AllItems.ToList();
+            allHandlers.Sort();
+            return InvokeOn(allHandlers, eventArgs);
+        }
+
+        internal static T InvokeAssembly(Assembly asm, T eventArgs)
+        {
+            var asmHandlers = Instance.handlers[asm].ToList();
+            asmHandlers.Sort();
+            return InvokeOn(asmHandlers, eventArgs);
         }
     }
 }

--- a/PathfinderAPI/PathfinderAPI.csproj
+++ b/PathfinderAPI/PathfinderAPI.csproj
@@ -91,9 +91,9 @@
     <Compile Include="Daemon\BaseDaemon.cs" />
     <Compile Include="Daemon\DaemonManager.cs" />
     <Compile Include="Event\EventManager.cs" />
-    <Compile Include="Event\Gameplay\LoadEvent.cs" />
-    <Compile Include="Event\Gameplay\PostLoadEvent.cs" />
-    <Compile Include="Event\Gameplay\UnloadEvent.cs" />
+    <Compile Include="Event\BepInEx\LoadEvent.cs" />
+    <Compile Include="Event\BepInEx\PostLoadEvent.cs" />
+    <Compile Include="Event\BepInEx\UnloadEvent.cs" />
     <Compile Include="Event\Gameplay\CommandExecuteEvent.cs" />
     <Compile Include="Event\Gameplay\ExecutableExecuteEvent.cs" />
     <Compile Include="Event\Gameplay\OSUpdateEvent.cs" />

--- a/PathfinderAPI/PathfinderAPI.csproj
+++ b/PathfinderAPI/PathfinderAPI.csproj
@@ -91,6 +91,9 @@
     <Compile Include="Daemon\BaseDaemon.cs" />
     <Compile Include="Daemon\DaemonManager.cs" />
     <Compile Include="Event\EventManager.cs" />
+    <Compile Include="Event\Gameplay\LoadEvent.cs" />
+    <Compile Include="Event\Gameplay\PostLoadEvent.cs" />
+    <Compile Include="Event\Gameplay\UnloadEvent.cs" />
     <Compile Include="Event\Gameplay\CommandExecuteEvent.cs" />
     <Compile Include="Event\Gameplay\ExecutableExecuteEvent.cs" />
     <Compile Include="Event\Gameplay\OSUpdateEvent.cs" />

--- a/PathfinderAPI/Util/AssemblyAssociatedList.cs
+++ b/PathfinderAPI/Util/AssemblyAssociatedList.cs
@@ -10,12 +10,22 @@ namespace Pathfinder.Util
         private Dictionary<Assembly, List<T>> asmDictionary = new Dictionary<Assembly, List<T>>();
         public ReadOnlyCollection<T> AllItems { get; private set; } = new ReadOnlyCollection<T>(new List<T>());
 
+        public ReadOnlyCollection<T> this[Assembly assembly]
+        {
+            get
+            {
+                if(!asmDictionary.TryGetValue(assembly, out var list))
+                    return new ReadOnlyCollection<T>(new List<T>());
+                return new ReadOnlyCollection<T>(list);
+            }
+        }
+
         public void Add(T val, Assembly owner)
         {
             if (!asmDictionary.ContainsKey(owner))
                 asmDictionary[owner] = new List<T>();
             asmDictionary[owner].Add(val);
-            
+
             RefreshCache();
         }
 


### PR DESCRIPTION
This is necessary for my changes to the updater, as it relies on PostLoad.

### Added HacknetPlugin.PostLoad
* Operates after all plugins are loaded
* Common use case is acting upon the plugin list
### Added Load, PostLoad, and Unload events
* Enables organization and separation of load related behavior
* With #127 load behavior can be automated without a plugin Load method
* Load and PostLoad events run after their method counterparts
* Unload events run before its method counterpart
* PostLoad and Unload are patches to the related HacknetPlugin methods
* Load is patched to postfix HacknetChainloader.LoadPlugin
### Added Assembly indexer getter to AssemblyAssociatedList
* Enables retrieving Assembly specific lists
* Useful for Load events
### Added EventManager.InvokeAssembly
* Used for Load events
### EventManager's invoke behavior put into a private static method