### PR TITLE
Fix OSLoadedEvent not firing

### DIFF
--- a/PathfinderAPI/Event/Loading/OSLoadedEvent.cs
+++ b/PathfinderAPI/Event/Loading/OSLoadedEvent.cs
@@ -3,6 +3,7 @@ using HarmonyLib;
 
 namespace Pathfinder.Event.Loading
 {
+    [HarmonyPatch]
     public class OSLoadedEvent : PathfinderEvent
     {
         public OS Os { get; }


### PR DESCRIPTION
If you don't annotate the class with `[HarmonyPatch]`, you ain't running the patches in it.