### PR TITLE
Fix #152

### DIFF
--- a/PathfinderAPI/Executable/ExecutableManager.cs
+++ b/PathfinderAPI/Executable/ExecutableManager.cs
@@ -156,13 +156,8 @@ public static class ExecutableManager
             x => x.MatchBr(out branchCondition),
             // for (int j = 0; j < PortExploits.exeNums.Count; j++)
             // int j = 0;
-            x => x.MatchNop(),
-            x => x.MatchLdcI4(0),
-            x => x.MatchStloc(3),
-            x => x.MatchBr(out ILLabel _)
+            x => x.MatchNop()
         );
-
-        c.Index -= 3;
 
         c.Emit(OpCodes.Ldloc_1);
         c.Emit(OpCodes.Ldloc_2);

--- a/PathfinderAPI/Executable/ExecutableManager.cs
+++ b/PathfinderAPI/Executable/ExecutableManager.cs
@@ -170,7 +170,7 @@ public static class ExecutableManager
 
         c.EmitDelegate<Func<Folder, int, OS, bool>>((folder, i, os) => {
             if(CustomExes.Any(x => x != null && x.Value.ExeData == folder.files[i].data)){
-				os.write(folder.files[i].name.Replace(".exe", ""));
+                os.write(folder.files[i].name.Replace(".exe", ""));
                 return true;
             }
             return false;

--- a/PathfinderAPI/Executable/ExecutableManager.cs
+++ b/PathfinderAPI/Executable/ExecutableManager.cs
@@ -169,7 +169,7 @@ public static class ExecutableManager
         c.Emit(OpCodes.Ldarg_1);
 
         c.EmitDelegate<Func<Folder, int, OS, bool>>((folder, i, os) => {
-            if(CustomExes.Any(x => x != null && x.Value.ExeData == folder.files[i].data)){
+            if(CustomExes.Any(x => x.Value.ExeData == folder.files[i].data)){
                 os.write(folder.files[i].name.Replace(".exe", ""));
                 return true;
             }


### PR DESCRIPTION
Patches `Programs.execute` to also check if a file has data from `CustomExes`.
The patch is currently implemented with `ILManipulator`, but `Programs.execute` might be small enough to warrant replacing the function entirely with a prefix patch.