### PR TITLE
Fix #145

### DIFF
--- a/PathfinderAPI/Replacements/ContentLoader.cs
+++ b/PathfinderAPI/Replacements/ContentLoader.cs
@@ -906,14 +906,17 @@ public static class ContentLoader
                 ComputerLookup.Add(eosDevice);
             ComputerLookup.Add(ret);
 
-            var devices = new List<Computer>(eosList);
-            var origOs = os;
+            if (eosList.Count > 0)
+            {
+                var devices = new List<Computer>(eosList);
+                var origOs = os;
 
-            ComputerLoader.postAllLoadedActions += ()=>{
-                int i = origOs.netMap.nodes.IndexOf(ret);
-                foreach (Computer eosDevice in devices)
-                    eosDevice.links.Add(i);
-            };
+                ComputerLoader.postAllLoadedActions += ()=>{
+                    int i = origOs.netMap.nodes.IndexOf(ret);
+                    foreach (Computer eosDevice in devices)
+                        eosDevice.links.Add(i);
+                };
+            }
         }
 
         os = null;

--- a/PathfinderAPI/Replacements/ContentLoader.cs
+++ b/PathfinderAPI/Replacements/ContentLoader.cs
@@ -903,11 +903,17 @@ public static class ContentLoader
         {
             os.netMap.nodes.Add(ret);
             foreach (Computer eosDevice in eosList)
-            {
-                eosDevice.links.Add(os.netMap.nodes.Count - 1);
                 ComputerLookup.Add(eosDevice);
-            }
             ComputerLookup.Add(ret);
+
+            var devices = new List<Computer>(eosList);
+            var origOs = os;
+
+            ComputerLoader.postAllLoadedActions += ()=>{
+                int i = origOs.netMap.nodes.IndexOf(ret);
+                foreach (Computer eosDevice in devices)
+                    eosDevice.links.Add(i);
+            };
         }
 
         os = null;


### PR DESCRIPTION
eOS devices link back to the original node during `postAllLoadedActions` to get the correct index.