### PR TITLE
Fix #168 Generated nodes missing ports again

### DIFF
--- a/PathfinderAPI/Replacements/ReplacementsCommon.cs
+++ b/PathfinderAPI/Replacements/ReplacementsCommon.cs
@@ -8,6 +8,7 @@ using Pathfinder.Util.XML;
 
 namespace Pathfinder.Replacements;
 
+[HarmonyPatch]
 public static class ReplacementsCommon
 {
     public static MemoryContents LoadMemoryContents(ElementInfo info)


### PR DESCRIPTION
`[HarmonyPatch]` was missing from `ReplacementsCommon`.