### PR TITLE
(Base game) Fix tutorial startup for extensions

### DIFF
--- a/PathfinderAPI/BaseGameFixes/FixTutorialStartup.cs
+++ b/PathfinderAPI/BaseGameFixes/FixTutorialStartup.cs
@@ -1,0 +1,18 @@
+using Hacknet;
+using Hacknet.Extensions;
+using HarmonyLib;
+
+namespace Pathfinder.BaseGameFixes;
+
+[HarmonyPatch]
+public static class FixTutorialStartup
+{
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(AdvancedTutorial), nameof(AdvancedTutorial.Killed))]
+    internal static bool AdvancedTutorialLoadStartingMission(AdvancedTutorial __instance)
+    {
+        if (!__instance.os.multiplayer && __instance.os.initShowsTutorial && Settings.IsInExtensionMode && __instance.os.currentMission is null)
+            __instance.os.currentMission = (ActiveMission)ComputerLoader.readMission(ExtensionLoader.ActiveExtensionInfo.FolderPath + "/" + ExtensionLoader.ActiveExtensionInfo.StartingMissionPath);
+        return true;
+    }
+}


### PR DESCRIPTION
`firstTimeInit` doesn't set `os.currentMission` when `StartsWithTutorial` is enabled.
(If in the base game it's already set by this point.)
`AdvancedTutorial.Killed` expects it to be set.