### PR TITLE
Fix NRE for `ActiveExtensionInfo` in `FixTutorialStartup`

### DIFF
--- a/PathfinderAPI/BaseGameFixes/FixTutorialStartup.cs
+++ b/PathfinderAPI/BaseGameFixes/FixTutorialStartup.cs
@@ -22,7 +22,7 @@ public static class FixTutorialStartup
         c.Emit(OpCodes.Ldarg_1);
         c.EmitDelegate<Action<OS>>(os =>
         {
-            if (ExtensionLoader.ActiveExtensionInfo.StartingMissionPath != null)
+            if (Settings.IsInExtensionMode && ExtensionLoader.ActiveExtensionInfo?.StartingMissionPath != null)
                 os.currentMission = (ActiveMission)ComputerLoader.readMission(ExtensionLoader.ActiveExtensionInfo.FolderPath + "/" + ExtensionLoader.ActiveExtensionInfo.StartingMissionPath);
         });
     }


### PR DESCRIPTION
Forgot to test the PR for the base game.