### PR TITLE
Add `CanBeKilled` to `GameExecutable`

### DIFF
--- a/PathfinderAPI/Executable/ExeModuleExtensions.cs
+++ b/PathfinderAPI/Executable/ExeModuleExtensions.cs
@@ -4,9 +4,17 @@ namespace Pathfinder.Executable;
 
 public static class ExeModuleExtensions
 {
+    public static bool CanKill(this ExeModule module) =>
+        !(
+            !module.os.exes.Contains(module) ||
+            ((module is GameExecutable gameExe) && !gameExe.CanBeKilled) ||
+            ((module is DLCIntroExe introExe) && !((introExe.State == DLCIntroExe.IntroState.NotStarted) || (introExe.State == DLCIntroExe.IntroState.Exiting))) ||
+            ((module is ExtensionSequencerExe seqExe) && (seqExe.state == ExtensionSequencerExe.SequencerExeState.Active))
+        );
+
     public static bool Kill(this ExeModule module)
     {
-        if(!module.os.exes.Contains(module))
+        if(!module.CanKill())
             return false;
         module.Killed();
         return module.os.exes.Remove(module);

--- a/PathfinderAPI/Executable/GameExecutable.cs
+++ b/PathfinderAPI/Executable/GameExecutable.cs
@@ -158,14 +158,6 @@ public class GameExecutable : BaseExecutable
 
     public sealed override void Killed()
     {
-        if (!CanBeKilled)
-        {
-            os.delayer.Post(
-                (ActionDelayer x) => !os.exes.Contains(this),
-                () => os.exes.Add(this)
-            );
-            return;
-        }
         Result = CompletionResult.Killed;
         needsRemoval = true;
         Completed();

--- a/PathfinderAPI/Executable/GameExecutable.cs
+++ b/PathfinderAPI/Executable/GameExecutable.cs
@@ -38,7 +38,6 @@ public class GameExecutable : BaseExecutable
     public virtual bool CanAddToSystem { get; set; } = true;
     /// <summary>
     /// Determines whether the executable can be killed
-    /// If set to false, the executable will be re-added after it has been removed
     /// </summary>
     public virtual bool CanBeKilled { get; set; } = true;
     /// <summary>

--- a/PathfinderAPI/Executable/GameExecutable.cs
+++ b/PathfinderAPI/Executable/GameExecutable.cs
@@ -37,6 +37,11 @@ public class GameExecutable : BaseExecutable
     /// </summary>
     public virtual bool CanAddToSystem { get; set; } = true;
     /// <summary>
+    /// Determines whether the executable can be killed
+    /// If set to false, the executable will be re-added after it has been removed
+    /// </summary>
+    public virtual bool CanBeKilled { get; set; } = true;
+    /// <summary>
     /// Written to the terminal if failed or errored when not null
     /// </summary>
     /// <value></value>
@@ -153,6 +158,14 @@ public class GameExecutable : BaseExecutable
 
     public sealed override void Killed()
     {
+        if (!CanBeKilled)
+        {
+            os.delayer.Post(
+                (ActionDelayer x) => !os.exes.Contains(this),
+                () => os.exes.Add(this)
+            );
+            return;
+        }
         Result = CompletionResult.Killed;
         needsRemoval = true;
         Completed();


### PR DESCRIPTION
Improves base game behavior where `DLCIntroExe` and `ExtensionSequencerExe` will, when killed, under certain conditions, re-instantiate themselves and add to `OS.exes` on the next tick to prevent being killed.

If one of those executables has its conditions met, or a `GameExecutable` has its `CanBeKilled` property set, the executable cannot be removed by `Programs.kill` or `ExeModuleExtensions.Kill`.