### PR TITLE
Stop using `loadAssignGameNodes`

### DIFF
--- a/PathfinderAPI/Replacements/SaveLoader.cs
+++ b/PathfinderAPI/Replacements/SaveLoader.cs
@@ -1,4 +1,4 @@
-﻿using System.Reflection;
+using System.Reflection;
 using Hacknet;
 using Hacknet.Factions;
 using Hacknet.Localization;
@@ -124,8 +124,6 @@ public static class SaveLoader
         {
             foreach (var daemon in os.netMap.nodes.SelectMany(x => x.daemons))
                 daemon.loadInit();
-
-            os.netMap.loadAssignGameNodes();
         }, ParseOption.FireOnEnd);
         executor.RegisterExecutor("HacknetSave.NetworkMap.network.computer", (exec, info) =>
             {
@@ -547,6 +545,9 @@ public static class SaveLoader
                 break;
             case "mail":
                 os.netMap.mailServer = comp;
+                break;
+            case "academic":
+                os.netMap.academicDatabase = comp;
                 break;
         }
 

--- a/PathfinderAPI/Replacements/SaveWriter.cs
+++ b/PathfinderAPI/Replacements/SaveWriter.cs
@@ -486,6 +486,10 @@ public static class SaveWriter
         {
             spec = "player";
         }
+        if (node.Equals(node.os.netMap.academicDatabase)) // academicDatabase can be null
+        {
+            spec = "academic";
+        }
         result.SetAttributeValue("spec", spec);
         result.SetAttributeValue("id", node.idName);
         if (node.icon != null)


### PR DESCRIPTION
`loadAssignGameNodes` redundantly reassigns `OS.netMap.mailServer` to the node with ID `jmail` instead of the node marked with `spec` value `mail` in the save file.

In the base game this doesn't matter since you can't change `mailServer`, but if a plugin changes `mailServer` to a different node, after a save and reload, it will revert back to `jmail`.

PR removes the call to `loadAssignGameNodes` from `SaveLoader`.
However, it was responsible for assigning `OS.netMap.academicDatabase`.
`academicDatabase` is now given a `spec` value `academic` in the save file and can also be reassigned by a plugin.