### PR TITLE
Create `ExecutableListEvent`

### DIFF
--- a/PathfinderAPI/Event/Gameplay/ExecutableListEvent.cs
+++ b/PathfinderAPI/Event/Gameplay/ExecutableListEvent.cs
@@ -1,0 +1,47 @@
+using Hacknet;
+using HarmonyLib;
+
+namespace Pathfinder.Event.Gameplay;
+
+[HarmonyPatch]
+public class ExecutableListEvent : PathfinderEvent
+{
+    public OS OS { get; }
+
+    public List<string> EmbeddedExes { get; } = new List<string>
+    {
+        "PortHack", "ForkBomb", "Shell", "Tutorial"
+    };
+    public Dictionary<FileEntry, bool> BinExes { get; }
+
+    public ExecutableListEvent(OS os, Dictionary<FileEntry, bool> binExes)
+    {
+        OS = os;
+        BinExes = binExes;
+    }
+
+    [HarmonyPrefix]
+    [HarmonyPatch(typeof(Programs), nameof(Programs.execute))]
+    private static bool ProgramsExecuteReplacement(string[] args, OS os){
+        var binFiles = (os.connectedComp ?? os.thisComputer).files.root.searchForFolder("bin").files; // folders[2].files;
+
+        var binExes = new Dictionary<FileEntry, bool>();
+        foreach (FileEntry exeFile in binFiles)
+            binExes[exeFile] =
+                PortExploits.crackExeData        .Any(x => x.Value == exeFile.data) ||
+                PortExploits.crackExeDataLocalRNG.Any(x => x.Value == exeFile.data);
+
+        var programsExecute = new ExecutableListEvent(os, binExes);
+        EventManager<ExecutableListEvent>.InvokeAll(programsExecute);
+
+        os.write("Available Executables:\n");
+        
+        foreach (string embedded in programsExecute.EmbeddedExes)
+            os.write(embedded);
+        foreach (FileEntry file in binFiles.Where(x => binExes[x]))
+            os.write(file.name.Replace(".exe", ""));
+
+        os.write(" ");
+        return false;
+    }
+}

--- a/PathfinderAPI/Event/Gameplay/ExecutableListEvent.cs
+++ b/PathfinderAPI/Event/Gameplay/ExecutableListEvent.cs
@@ -23,7 +23,7 @@ public class ExecutableListEvent : PathfinderEvent
     [HarmonyPrefix]
     [HarmonyPatch(typeof(Programs), nameof(Programs.execute))]
     private static bool ProgramsExecuteReplacement(string[] args, OS os){
-        var binFiles = (os.connectedComp ?? os.thisComputer).files.root.searchForFolder("bin").files; // folders[2].files;
+        var binFiles = os.thisComputer.files.root.searchForFolder("bin").files; // folders[2].files;
 
         var binExes = new Dictionary<FileEntry, bool>();
         foreach (FileEntry exeFile in binFiles)

--- a/PathfinderAPI/Executable/ExecutableManager.cs
+++ b/PathfinderAPI/Executable/ExecutableManager.cs
@@ -28,6 +28,7 @@ public static class ExecutableManager
     {
         EventManager<TextReplaceEvent>.AddHandler(GetTextReplacementExe);
         EventManager<ExecutableExecuteEvent>.AddHandler(OnExeExecute);
+        EventManager<ExecutableListEvent>.AddHandler(OnExecutableList);
         EventManager.onPluginUnload += OnPluginUnload;
     }
 
@@ -139,46 +140,14 @@ public static class ExecutableManager
         }
         return true;
     }
-    
-    [HarmonyILManipulator]
-    [HarmonyPatch(typeof(Programs), nameof(Programs.execute))]
-    private static void programsExecuteFix(ILContext il){
-        var c = new ILCursor(il);
 
-        ILLabel branchCondition = null;
-
-        c.GotoNext(MoveType.After,
-            // for (int i = 0; i < folder.files.Count; i++)
-            // int i = 0;
-            x => x.MatchNop(),
-            x => x.MatchLdcI4(0),
-            x => x.MatchStloc(2),
-            x => x.MatchBr(out branchCondition),
-            // for (int j = 0; j < PortExploits.exeNums.Count; j++)
-            // int j = 0;
-            x => x.MatchNop()
-        );
-
-        c.Emit(OpCodes.Ldloc_1);
-        c.Emit(OpCodes.Ldloc_2);
-        c.Emit(OpCodes.Ldarg_1);
-
-        c.EmitDelegate<Func<Folder, int, OS, bool>>((folder, i, os) => {
-            if(CustomExes.Any(x => x.ExeData == folder.files[i].data)){
-                os.write(folder.files[i].name.Replace(".exe", ""));
-                return true;
-            }
-            return false;
-        });
-
-        int i = c.Index;
-
-        c.GotoLabel(branchCondition, MoveType.Before);
-        c.Index -= 5;
-        ILLabel branchIncrement = c.MarkLabel();
-
-        c.Index = i;
-        c.Emit(OpCodes.Brtrue, branchIncrement);
+    private static void OnExecutableList(ExecutableListEvent e)
+    {
+        foreach (FileEntry exeFile in e.BinExes.Keys.ToList())
+        {
+            if(CustomExes.Any(x => x.ExeData == exeFile.data))
+                e.BinExes[exeFile] = true;
+        }
     }
 
     [HarmonyILManipulator]


### PR DESCRIPTION
`ExecutableListEvent` allows plugins to add to the output of `Programs.execute` without each having to patch the method.
It preserves the order of the outputs - first are embedded executables, and then are all exe files from `bin/` (in order) that contain valid binary data.