### PR TITLE
Fix #197 Extension plugins are unloaded in a bad order

### DIFF
--- a/PathfinderAPI/Meta/Load/AttributeManager.cs
+++ b/PathfinderAPI/Meta/Load/AttributeManager.cs
@@ -16,11 +16,10 @@ internal static class AttributeManager
         var c = new ILCursor(il);
 
         c.GotoNext(
-            x => x.MatchLdloc(1),
             x => x.MatchCallvirt(AccessTools.Method(typeof(HacknetPlugin), nameof(HacknetPlugin.Load)))
         );
 
-        c.Emit(OpCodes.Ldloc, 1);
+        c.Emit(OpCodes.Dup);
         c.Emit(OpCodes.Call, AccessTools.Method(typeof(AttributeManager), nameof(ReadAttributesFor)));
     }
 


### PR DESCRIPTION
Fixes #197.
Populate `TemporaryPluginGUIDs` as extension plugins are loaded, not when discovered.