### PR TITLE
Add FlickeringText GetReportString null handler

### DIFF
--- a/PathfinderAPI/BaseGameFixes/FlickeringTextReportNull.cs
+++ b/PathfinderAPI/BaseGameFixes/FlickeringTextReportNull.cs
@@ -1,0 +1,23 @@
+using System.Reflection;
+using Hacknet.Effects;
+using HarmonyLib;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+
+namespace Pathfinder.BaseGameFixes;
+
+[HarmonyPatch]
+public static class FlickeringTextReportNull {
+	[HarmonyPatch(typeof(FlickeringTextEffect), nameof(FlickeringTextEffect.GetReportString))]
+	[HarmonyILManipulator]
+	private static void GetReportStringManipulator(ILContext context) {
+		ILCursor cursor = new(context);
+
+		ILLabel unskipLabel = context.DefineLabel();
+		cursor.Emit(OpCodes.Ldsfld, typeof(FlickeringTextEffect).GetField(nameof(FlickeringTextEffect.LinedItemTarget), BindingFlags.Static | BindingFlags.Public));
+		cursor.Emit(OpCodes.Brtrue, unskipLabel);
+		cursor.Emit(OpCodes.Ldstr, "FlickeringTextEffect was not used in this execution.");
+		cursor.Emit(OpCodes.Ret);
+		unskipLabel.Target = cursor.Next;
+	}
+}


### PR DESCRIPTION
This fixes a base-game issue where exceptions thrown in `DisplayModule.Draw` could crash the game to desktop, if the Main Menu was bypassed (e.g. by launching an exception with `-extstart`).

To reproduce the original issue:
1. Create an Extension with the example broken node
   1. This Extension must have an empty `Missions/EmptyDirectory` directory.
3. Connect to the node (`connect err::mls_nosvc`)
4. Wait 3 frames
5. Observe the game hard-crash

Example Broken Node:
```xml
<Computer id="err::mls_nosvc" name="Mission Listing Server without a serviceName" type="4" ip="err::mls_nosvc">
	<LogoDaemon Name="Daemon To Prevent Crash On initDaemons()" />
	<!-- no 'name' attribute on this element -->
	<variableMissionListingServer articleFolderPath="Missions/EmptyDirectory"  />
</Computer>
```