### PR TITLE
Add KeepBranchesOnMailMissionCompletion

### DIFF
--- a/PathfinderAPI/BaseGameFixes/KeepBranchesOnMailMissionCompletion.cs
+++ b/PathfinderAPI/BaseGameFixes/KeepBranchesOnMailMissionCompletion.cs
@@ -1,0 +1,39 @@
+using Hacknet;
+using HarmonyLib;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+
+namespace Pathfinder.BaseGameFixes;
+
+[HarmonyPatch]
+public static class KeepBranchesOnMailMissionCompletion {
+	[HarmonyPatch(typeof(MailServer), nameof(MailServer.doRespondDisplay))]
+	[HarmonyILManipulator]
+	public static void DoRespondDisplayManipulator(ILContext context) {
+		ILCursor cursor = new(context);
+
+		cursor.GotoNext(MoveType.After,
+			x => x.MatchLdarg(0),
+			x => x.MatchLdarg(0),
+			x => x.MatchLdfld<Hacknet.Daemon>("os"),
+			x => x.MatchLdfld<OS>("branchMissions"),
+			x => x.MatchLdloc(4),
+			x => x.MatchCallvirt(out _),
+			x => x.MatchCall<MailServer>("attemptCompleteMission"),
+			x => x.MatchStloc(11)
+		);
+		Instruction startOfRange = cursor.Next;
+
+		cursor.GotoNext(MoveType.After,
+			x => x.MatchLdarg(0),
+			x => x.MatchLdfld<Hacknet.Daemon>("os"),
+			x => x.MatchLdfld<OS>("branchMissions"),
+			x => x.MatchCallvirt(out _)
+		);
+		Instruction endOfRange = cursor.Prev;
+
+		cursor.Goto(startOfRange);
+		int count = cursor.Instrs.IndexOf(endOfRange) - cursor.Instrs.IndexOf(startOfRange) + 1;
+		cursor.RemoveRange(count);
+	}
+}

--- a/PathfinderAPI/BaseGameFixes/KeepBranchesOnMailMissionCompletion.cs
+++ b/PathfinderAPI/BaseGameFixes/KeepBranchesOnMailMissionCompletion.cs
@@ -1,7 +1,9 @@
 using Hacknet;
 using HarmonyLib;
+using Mono.Cecil;
 using Mono.Cecil.Cil;
 using MonoMod.Cil;
+using MonoMod.Utils;
 
 namespace Pathfinder.BaseGameFixes;
 
@@ -18,7 +20,10 @@ public static class KeepBranchesOnMailMissionCompletion {
 			x => x.MatchLdfld<Hacknet.Daemon>("os"),
 			x => x.MatchLdfld<OS>("branchMissions"),
 			x => x.MatchLdloc(4),
-			x => x.MatchCallvirt(out _),
+			x => x.MatchCallvirt(out MethodReference method) &&
+				method.DeclaringType.Is(typeof(List<ActiveMission>)) &&
+				method.Name == "get_Item"
+			,
 			x => x.MatchCall<MailServer>("attemptCompleteMission"),
 			x => x.MatchStloc(11)
 		);
@@ -28,7 +33,9 @@ public static class KeepBranchesOnMailMissionCompletion {
 			x => x.MatchLdarg(0),
 			x => x.MatchLdfld<Hacknet.Daemon>("os"),
 			x => x.MatchLdfld<OS>("branchMissions"),
-			x => x.MatchCallvirt(out _)
+			x => x.MatchCallvirt(out MethodReference method) &&
+				method.DeclaringType.Is(typeof(List<ActiveMission>)) &&
+				method.Name == "Clear"
 		);
 		Instruction endOfRange = cursor.Prev;
 


### PR DESCRIPTION
This fixes a base-game issue where completing a branch mission via a MailServer erroneously clears out the branch missions of the *next* mission.

The short of it is: we delete these lines from `Hacknet.MailServer->doRespondDisplay`:
```csharp
          for (int index = 0; index < this.os.branchMissions.Count && !flag; ++index)
          {
            flag = this.attemptCompleteMission(this.os.branchMissions[index]);
            // ------------------------ >8 ------------------------
            if (flag)
              this.os.branchMissions.Clear();
            // ------------------------ >8 ------------------------
          }
```

Note that if `attemptCompleteMission` returns `true`, the `OS`'s `activeMission` and `branchMissions` have already been set to the values for the next mission by the mission completion code.

----

### Compatibility impact

The changes from this PR fix an issue with the base game's "ThemeHack"/"Naix" missions. 

Extension behavior may also be altered, though I'm not aware of any Extensions *intentionally* using this behavior. Conversely, I am aware of one in-development Extension that includes a workaround for this issue.