### PR TITLE
Create `HacknetPlugin.UserConfig`

### DIFF
--- a/BepInEx.Hacknet/HacknetPlugin.cs
+++ b/BepInEx.Hacknet/HacknetPlugin.cs
@@ -1,6 +1,8 @@
-﻿using BepInEx.Logging;
+using BepInEx.Logging;
 using BepInEx.Configuration;
 using HarmonyLib;
+using Hacknet.Extensions;
+using HN = global::Hacknet;
 
 namespace BepInEx.Hacknet;
 
@@ -14,12 +16,38 @@ public abstract class HacknetPlugin
 
         Log = Logger.CreateLogSource(metadata.Name);
 
-        Config = new ConfigFile(System.IO.Path.Combine(Paths.ConfigPath, metadata.GUID + ".cfg"), false, metadata);
+        InstalledGlobally = !HN.Settings.IsInExtensionMode;
+
+        Config = new ConfigFile(Path.Combine(Paths.ConfigPath, metadata.GUID + ".cfg"), false, metadata);
+
+        if (!InstalledGlobally)
+            UserConfig = new ConfigFile(
+                Path.Combine("BepInEx/config/", ExtensionLoader.ActiveExtensionInfo.GetFoldersafeName(), metadata.GUID + ".cfg"),
+                false,
+                metadata
+            );
     }
 
     public ManualLogSource Log { get; }
 
+    public bool InstalledGlobally { get; }
+
+    /// <summary>
+    /// If this plugin is installed in an extension, holds a <see cref="ConfigFile"/> to be edited by the extension developer.
+    /// <br/>
+    /// Otherwise, if its installed globally, holds a <see cref="ConfigFile"/> to be edited by the user.
+    /// <br/><br/>
+    /// For the extension player's <see cref="ConfigFile"/>, see <see cref="UserConfig"/>.  
+    /// </summary>
     public ConfigFile Config { get; }
+    /// <summary>
+    /// If this plugin is installed in an extension, holds a <see cref="ConfigFile"/> to be edited by the extension player.
+    /// <br/>
+    /// Otherwise, if its installed globally, holds the value <c>null</c>.
+    /// <br/><br/>
+    /// For the extension developer's <see cref="ConfigFile"/>, see <see cref="Config"/>.  
+    /// </summary>
+    public ConfigFile UserConfig { get; }
 
     public Harmony HarmonyInstance { get; set; }
 


### PR DESCRIPTION
Fixes #167, but does not implement an automatic way for user config settings to override extension config ones.