### PR TITLE
Add patch to avoid null-deref in ThemeChanger

### DIFF
--- a/BepInEx.Hacknet/HacknetChainloader.cs
+++ b/BepInEx.Hacknet/HacknetChainloader.cs
@@ -21,7 +21,7 @@ public class HacknetChainloader : BaseChainloader<HacknetPlugin>
             "BepInEx/core/BepInEx.Hacknet.dll"
         );
 
-    public const string VERSION = "5.3.3";
+    public const string VERSION = "5.3.4";
     public static readonly Version Version = Version.Parse(VERSION);
         
     public static HacknetChainloader Instance;

--- a/PathfinderAPI/BaseGameFixes/AvoidNullDerefOnThemeChange.cs
+++ b/PathfinderAPI/BaseGameFixes/AvoidNullDerefOnThemeChange.cs
@@ -1,0 +1,53 @@
+using System;
+using System.Reflection;
+using Hacknet;
+using HarmonyLib;
+using Mono.Cecil.Cil;
+using MonoMod.Cil;
+
+namespace Pathfinder.BaseGameFixes;
+
+[HarmonyPatch]
+internal static class AvoidNullDerefOnThemeChange {
+
+	[HarmonyILManipulator]
+	[HarmonyPatch(typeof(ThemeChangerExe), nameof(ThemeChangerExe.ApplyTheme))]
+	internal static void ForcePlayerXServerToExist(ILContext context, MethodBase original) {
+		if (original is null)
+			return;
+
+		ILCursor il = new(context);
+		ILLabel fileIsNull = null!;
+		ILLabel afterConditionals = il.DefineLabel();
+		Type str = typeof(string);
+		FieldInfo strEmpty = AccessTools.Field(str, nameof(string.Empty));
+		ConstructorInfo fileCtor = AccessTools.Constructor(typeof(FileEntry), [str, str]);
+		FieldInfo folderFiles = AccessTools.Field(typeof(Folder), nameof(Folder.files));
+		MethodInfo fileListAdd = AccessTools.Method(folderFiles.FieldType, nameof(Folder.files.Add));
+
+		il.GotoNext([ // doesn't matter where we move relative to these, we just need the label at the end of this instruction set
+			i => i.MatchLdloc(2),
+			i => i.MatchLdnull(),
+			i => i.MatchCeq(),
+			i => i.MatchStloc(6),
+			i => i.MatchLdloc(6),
+			i => i.MatchBrtrue(out fileIsNull),
+		]);
+
+		il.GotoLabel(fileIsNull, MoveType.Before); // we need to insert a branch after making the backup, in order to NOT make a duplicate file
+		il.Emit(OpCodes.Br, afterConditionals); // coming in from the part that ran when FileEntry is NOT null, making the backup theme file
+		il.MoveAfterLabels(); // now we need to inject AT the jump target for when the FileEntry IS null
+
+		il.Emit(OpCodes.Ldsfld, strEmpty); // [string.Empty]
+		il.Emit(OpCodes.Ldstr, "x-server.sys"); // [string.Empty, "x-server.sys"]
+		il.Emit(OpCodes.Newobj, fileCtor); // [FileEntry] new FileEntry(string.Empty, "x-server.sys")
+		il.Emit(OpCodes.Stloc_2); // []
+		il.Emit(OpCodes.Ldloc_1); // [Folder]
+		il.Emit(OpCodes.Ldfld, folderFiles); // [Folder.files]
+		il.Emit(OpCodes.Ldloc_2); // [Folder.files, FileEntry]
+		il.Emit(OpCodes.Callvirt, fileListAdd); // [] Folder.files.Add(FileEntry)
+
+		afterConditionals.Target = il.Next;
+	}
+
+}

--- a/PathfinderAPI/Replacements/MissionLoader.cs
+++ b/PathfinderAPI/Replacements/MissionLoader.cs
@@ -127,7 +127,7 @@ public static class MissionLoader
         executor.RegisterExecutor("mission.posting", (exec, info) =>
         {
             mission.postingTitle = info.Attributes.GetString("title", "UNKNOWN").Filter();
-            mission.postingBody = info.Content ?? "UNKNOWN";
+            mission.postingBody = (info.Content ?? "UNKNOWN").Filter();
             mission.postingAcceptFlagRequirements = info.Attributes.GetString("reqs").Split(Utils.commaDelim, StringSplitOptions.RemoveEmptyEntries);
             mission.requiredRank = info.Attributes.GetInt("requiredRank");
             mission.difficulty = info.Attributes.GetInt("difficulty");


### PR DESCRIPTION
If you try to use ThemeChanger while you don't have an `x-server.sys` file, the game attempts to reference a `FileEntry` object that's null, preventing your theme from being changed. This patch creates a new (empty) `x-server.sys` file in the event that one doesn't yet exist, both preventing a null reference error in the console and allowing ThemeChanger to work in such cases.

The empty file is _not_ backed up by ThemeChanger the way actually pre-existing x-servers are, so there will not be a new, empty backup file made.

The justification for this being possible is that changing your x-server is a simple file-copy operation, rather than a complex patch that would require an existing x-server. Even in non-modded Hacknet, you can change your theme by manually replacing your `x-server.sys` file, which suggests that ThemeChanger is effectively downloading (from a remote node) or copying (from your own node) an `x-server.sys` into place on your node, and then hot-reloading the new x-server in your OS. Since the file is logically replaced, no existing file is needed for the operation.