### PR TITLE
Add sequencer node dimming fix

### DIFF
--- a/PathfinderAPI/BaseGameFixes/SequencerNodeDimmingFix.cs
+++ b/PathfinderAPI/BaseGameFixes/SequencerNodeDimmingFix.cs
@@ -1,0 +1,17 @@
+﻿using Hacknet;
+
+using HarmonyLib;
+
+namespace Pathfinder.BaseGameFixes;
+
+[HarmonyPatch]
+public class SequencerNodeDimmingFix
+{
+    [HarmonyPostfix]
+    [HarmonyPatch(typeof(ExtensionSequencerExe), "Killed")]
+    static void FixSequencerNodeDimming(ExtensionSequencerExe __instance)
+    {
+        // This fixes a bug where nodes would continue to be dimmed after the sequencer is killed
+        __instance.os.netMap.DimNonConnectedNodes = false;
+    }
+}


### PR DESCRIPTION
[Ported from Stuxnet](https://github.com/AutumnRivers/StuxnetHN/blob/main/Patches/ExtSequencerPatch.cs)

Base game Hacknet has this really small yet extremely annoying bug (to me, at least) where nodes on the netmap don't get undimmed after the extension sequencer is killed. This doesn't happen with the campaign sequencer. This just flips one switch to tell Hacknet to undim the nodes when the sequencer is killed.