### PR TITLE
#213 prevent duplicate mod loading

### DIFF
--- a/BepInEx.Hacknet/HacknetChainloader.cs
+++ b/BepInEx.Hacknet/HacknetChainloader.cs
@@ -53,6 +53,19 @@ public class HacknetChainloader : BaseChainloader<HacknetPlugin>
         }
 
         var plugins = base.DiscoverPlugins();
+        
+        // Filter the list to those NOT already loaded, warn on duplicate plugins.
+        for (int i = plugins.Count - 1; i > -1; i--)
+        {
+            PluginInfo extPlugin = plugins[i];
+            
+            if (Plugins.ContainsKey(extPlugin.Metadata.GUID))
+            {
+                Log.LogWarning($"Skipped loading of '{extPlugin.Metadata.GUID}' as already loaded globally.");
+                plugins.RemoveAt(i);
+            }
+        }
+        
         return plugins;
     }
 

--- a/ExampleMod/ExampleMod.csproj
+++ b/ExampleMod/ExampleMod.csproj
@@ -29,7 +29,7 @@
     <PropertyGroup Label="Build">
         <TargetFramework>net472</TargetFramework>
         <TargetFrameworkProfile />
-        <LangVersion>12</LangVersion>
+        <LangVersion>10</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <AssemblySearchPaths>
         $(AssemblySearchPaths);

--- a/ExampleMod/ExampleMod.csproj
+++ b/ExampleMod/ExampleMod.csproj
@@ -29,7 +29,7 @@
     <PropertyGroup Label="Build">
         <TargetFramework>net472</TargetFramework>
         <TargetFrameworkProfile />
-        <LangVersion>10</LangVersion>
+        <LangVersion>12</LangVersion>
         <ImplicitUsings>enable</ImplicitUsings>
         <AssemblySearchPaths>
         $(AssemblySearchPaths);

--- a/ExampleMod/ExampleModPlugin.cs
+++ b/ExampleMod/ExampleModPlugin.cs
@@ -21,7 +21,7 @@ public class ExampleModPlugin2 : BepInEx.Hacknet.HacknetPlugin
         base.HarmonyInstance.PatchAll(typeof(PatchClass2));
 
         Pathfinder.Executable.ExecutableManager.RegisterExecutable<TestExe>("#PF_TEST_EXE#");
-        Pathfinder.Port.PortManager.RegisterPort("ex", "example port");
+        Pathfinder.Port.PortManager.RegisterPort("ex", "example port", 1515);
         Pathfinder.Daemon.DaemonManager.RegisterDaemon<TestDaemon>();
         Pathfinder.Command.CommandManager.RegisterCommand("pathfinder", TestCommand);
         Pathfinder.Mission.GoalManager.RegisterGoal<TestGoal>("resetIP");

--- a/PathfinderAPI/BaseGameFixes/AvoidNullDerefOnThemeChange.cs
+++ b/PathfinderAPI/BaseGameFixes/AvoidNullDerefOnThemeChange.cs
@@ -21,18 +21,18 @@ internal static class AvoidNullDerefOnThemeChange {
 		ILLabel afterConditionals = il.DefineLabel();
 		Type str = typeof(string);
 		FieldInfo strEmpty = AccessTools.Field(str, nameof(string.Empty));
-		ConstructorInfo fileCtor = AccessTools.Constructor(typeof(FileEntry), [str, str]);
+		ConstructorInfo fileCtor = AccessTools.Constructor(typeof(FileEntry), new[]{str, str});
 		FieldInfo folderFiles = AccessTools.Field(typeof(Folder), nameof(Folder.files));
 		MethodInfo fileListAdd = AccessTools.Method(folderFiles.FieldType, nameof(Folder.files.Add));
 
-		il.GotoNext([ // doesn't matter where we move relative to these, we just need the label at the end of this instruction set
+		il.GotoNext( // doesn't matter where we move relative to these, we just need the label at the end of this instruction set
 			i => i.MatchLdloc(2),
 			i => i.MatchLdnull(),
 			i => i.MatchCeq(),
 			i => i.MatchStloc(6),
 			i => i.MatchLdloc(6),
-			i => i.MatchBrtrue(out fileIsNull),
-		]);
+			i => i.MatchBrtrue(out fileIsNull)
+		);
 
 		il.GotoLabel(fileIsNull, MoveType.Before); // we need to insert a branch after making the backup, in order to NOT make a duplicate file
 		il.Emit(OpCodes.Br, afterConditionals); // coming in from the part that ran when FileEntry is NOT null, making the backup theme file


### PR DESCRIPTION
Updated mod loading to filter discovered plugins to those not already loaded. Warning log messages are generated for any duplicate mods detected, but as they're never loaded as "temporary" they don't get unloaded again after extension exit.

This PR also contains:
- A bugfix for changes introduced by last commit/PR.
- A bugfix [specifying port number] in ExampleMod, so that it would correctly load and I could use it to test the above changes. 