### PR TITLE
Have AddGameExecutable define exe bounds

### DIFF
--- a/PathfinderAPI/Executable/ExecutableManager.cs
+++ b/PathfinderAPI/Executable/ExecutableManager.cs
@@ -126,8 +126,12 @@ public static class ExecutableManager
             if(os.ramAvaliable >= exe.ramCost)
             {
                 exe.OnInitialize();
-                if(exe.CanAddToSystem)
+                if (exe.CanAddToSystem)
+                {
+                    exe.bounds.X = os.ram.bounds.X;
+                    exe.bounds.Width = os.ram.bounds.Width;
                     os.exes.Add(exe);
+                }
                 return;
             }
 


### PR DESCRIPTION
Currently, as it stands, when a plugin developer adds an executable via OS.AddGameExecutable, they have to manually define the bounds. This is very hacky, and very ugly. This commit fixes that. Any plugins manually defining bounds are unchanged - this works both ways.

# Screenshots

How it currently works if bounds are not manually defined:  
![365450_2511](https://github.com/user-attachments/assets/f4258da9-f7d7-4707-8705-a7316a03db80)

How it works with this commit:  
![365450_2512](https://github.com/user-attachments/assets/81ef35d2-f525-40cd-a732-b646a684f283)

Example of a mod manually defining and still working with this commit:  
![365450_2513](https://github.com/user-attachments/assets/e71a040e-31bf-41be-b8b7-ab0f17f7f114)
